### PR TITLE
Rename OrElse overloads that return TItem to GetOrElse

### DIFF
--- a/Funcky.Test/OptionTest.cs
+++ b/Funcky.Test/OptionTest.cs
@@ -218,8 +218,8 @@ namespace Funcky.Test
             Assert.Equal(some, none.OrElse(some));
             Assert.Equal(some, none.OrElse(none).OrElse(some));
             Assert.Equal(none, none.OrElse(none).OrElse(none));
-            Assert.Equal(1337, none.OrElse(1337));
-            Assert.Equal(1337, none.OrElse(none).OrElse(1337));
+            Assert.Equal(1337, none.GetOrElse(1337));
+            Assert.Equal(1337, none.OrElse(none).GetOrElse(1337));
         }
 
         [Fact]
@@ -279,7 +279,7 @@ namespace Funcky.Test
             };
 
             var maybe = some
-                .OrElse(sideEffect);
+                .GetOrElse(sideEffect);
 
             Assert.Equal(0, global);
         }

--- a/Funcky/Monads/Option/Option.Convenience.cs
+++ b/Funcky/Monads/Option/Option.Convenience.cs
@@ -13,13 +13,13 @@ namespace Funcky.Monads
         public Option<TItem> OrElse(Option<TItem> elseOption)
             => Match(none: elseOption, some: Option.Some);
 
-        public TItem OrElse(TItem elseOption)
-            => Match(none: elseOption, some: Identity);
-
         public Option<TItem> OrElse(Func<Option<TItem>> elseOption)
             => Match(none: elseOption, some: Option.Some);
 
-        public TItem OrElse(Func<TItem> elseOption)
+        public TItem GetOrElse(TItem elseOption)
+            => Match(none: elseOption, some: Identity);
+
+        public TItem GetOrElse(Func<TItem> elseOption)
             => Match(none: elseOption, some: Identity);
 
         public Option<TResult> AndThen<TResult>(Func<TItem, TResult> andThenFunction)

--- a/changelog.md
+++ b/changelog.md
@@ -19,7 +19,7 @@
 * Add overload for `Option<T>.SelectMany` that takes only a selector.
 
 ## 2.0.0-rc.1
-* Full nullable support introduced with C# 8 
+* Full nullable support introduced with C# 8
 * Rename `Option.From` -> `Option.FromNullable` and remove overload that takes non-nullable value types.
 * Use `Func<T, bool>` instead of `Predicate<T>` in predicate composition functions (`Functional.All`, `Functional.Any`, `Functional.Not`),
   because most APIs in `System` use `Func`.
@@ -30,6 +30,7 @@
 * `Exception` created by `Result` monad contains valid stack trace
 
 ## Unreleased
-* Move the `Ok` constructor of `Result<T>` to a non-generic class. This allows for the compiler to infer the generic type.  
-  Old: `Result<int>.Ok(10)`. New: `Result.Ok(10)`. 
+* Move the `Ok` constructor of `Result<T>` to a non-generic class. This allows for the compiler to infer the generic type.
+  Old: `Result<int>.Ok(10)`. New: `Result.Ok(10)`.
 * Add `IndexOfOrNone`, `LastIndexOfOrNone`, `IndexOfAnyOrNone` and `LastIndexOfAnyOrNone` extension methods to `string`.
+* Rename `OrElse` overloads that return the item to `GetOrElse` which improves overload resolution.


### PR DESCRIPTION
Resolves #65 