### PR TITLE
Remove overload for `Option.From` that flattens passed `Option`s.

### DIFF
--- a/Funcky.Test/OptionTest.cs
+++ b/Funcky.Test/OptionTest.cs
@@ -302,12 +302,12 @@ namespace Funcky.Test
         }
 
         [Fact]
-        public void GivenAnOptionOfAnOptionWeGetASimpleOption()
+        public void OptionFromDoesNotFlattenOptions()
         {
-            var option1 = Option.Some(1);
-            var option2 = Option.Some(option1);
-
-            Assert.Equal(option1, option2);
+            var option = Option.Some(Option.Some(1));
+            #pragma warning disable 183 // The given operation is always of the provided type
+            Assert.True(option is Option<Option<int>>);
+            #pragma warning restore 183
         }
 
         [Fact]

--- a/Funcky/Monads/Option/Option.Core.cs
+++ b/Funcky/Monads/Option/Option.Core.cs
@@ -95,10 +95,5 @@ namespace Funcky.Monads
         public static Option<TItem> Some<TItem>(TItem item)
             where TItem : notnull
             => new Option<TItem>(item);
-
-        [Pure]
-        public static Option<TItem> Some<TItem>(Option<TItem> item)
-            where TItem : notnull
-            => item;
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -43,3 +43,4 @@
 
 ## Unreleased
 * Add extension method for `HttpHeaders.TryGetValues`, which returns an `Option`.
+* Remove overload for `Option.From` that flattens passed `Option`s.


### PR DESCRIPTION
Resolves #84 