### PR TITLE
Equality stuff

### DIFF
--- a/Funcky.Test/OptionTest.cs
+++ b/Funcky.Test/OptionTest.cs
@@ -377,6 +377,38 @@ namespace Funcky.Test
                 MultiplyByTen(input));
         }
 
+        [Theory]
+        [MemberData(nameof(EqualOptions))]
+        public void EqualsReturnsTrueForEqualOptions(Option<int> lhs, Option<int> rhs)
+        {
+            Assert.True(lhs == rhs);
+        }
+
+        public static TheoryData<Option<int>, Option<int>> EqualOptions()
+            => new TheoryData<Option<int>, Option<int>>
+            {
+                { Option.Some(1), Option.Some(1) },
+                { Option<int>.None(), Option<int>.None() },
+            };
+
+        [Theory]
+        [MemberData(nameof(NotEqualOptions))]
+        public void EqualsReturnsFalseForNotEqualOptions(Option<int> lhs, Option<int> rhs)
+        {
+            Assert.True(lhs != rhs);
+        }
+
+        public static TheoryData<Option<int>, Option<int>> NotEqualOptions()
+            => new TheoryData<Option<int>, Option<int>>
+            {
+                { Option.Some(1), Option<int>.None() },
+                { Option<int>.None(), Option.Some(1) },
+                { Option<int>.None(), Option.Some(default(int)) },
+                { Option.Some(default(int)), Option<int>.None() },
+                { Option.Some(1), Option.Some(2) },
+                { Option.Some(2), Option.Some(1) },
+            };
+
         private static void Statement(int value)
         {
         }

--- a/Funcky/Monads/Either/Either.Core.cs
+++ b/Funcky/Monads/Either/Either.Core.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.Contracts;
 
 namespace Funcky.Monads
 {
-    public readonly partial struct Either<TLeft, TRight>
+    public readonly partial struct Either<TLeft, TRight> : IEquatable<Either<TLeft, TRight>>
     {
         private readonly TLeft _left;
         private readonly TRight _right;
@@ -69,8 +69,11 @@ namespace Funcky.Monads
 
         [Pure]
         public override bool Equals(object obj)
-            => obj is Either<TLeft, TLeft> other
-               && Equals(_side, other._side)
+            => obj is Either<TLeft, TRight> other && Equals(other);
+
+        [Pure]
+        public bool Equals(Either<TLeft, TRight> other)
+            => Equals(_side, other._side)
                && Equals(_right, other._right)
                && Equals(_left, other._left);
 

--- a/Funcky/Monads/Option/Option.Core.cs
+++ b/Funcky/Monads/Option/Option.Core.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.Contracts;
 
 namespace Funcky.Monads
 {
-    public readonly partial struct Option<TItem>
+    public readonly partial struct Option<TItem> : IEquatable<Option<TItem>>
         where TItem : notnull
     {
         private readonly bool _hasItem;
@@ -74,9 +74,11 @@ namespace Funcky.Monads
 
         [Pure]
         public override bool Equals(object obj)
-            => obj is Option<TItem> other
-               && Equals(_hasItem, other._hasItem)
-               && Equals(_item, other._item);
+            => obj is Option<TItem> other && Equals(other);
+
+        [Pure]
+        public bool Equals(Option<TItem> other)
+            => Equals(_hasItem, other._hasItem) && Equals(_item, other._item);
 
         [Pure]
         public override int GetHashCode()

--- a/Funcky/Monads/Option/Option.Core.cs
+++ b/Funcky/Monads/Option/Option.Core.cs
@@ -74,7 +74,9 @@ namespace Funcky.Monads
 
         [Pure]
         public override bool Equals(object obj)
-            => obj is Option<TItem> other && Equals(_item, other._item);
+            => obj is Option<TItem> other
+               && Equals(_hasItem, other._hasItem)
+               && Equals(_item, other._item);
 
         [Pure]
         public override int GetHashCode()

--- a/Funcky/Monads/Option/Option.Core.cs
+++ b/Funcky/Monads/Option/Option.Core.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.Contracts;
 
 namespace Funcky.Monads
 {
-    public readonly partial struct Option<TItem> : IEquatable<Option<TItem>>
+    public readonly partial struct Option<TItem>
         where TItem : notnull
     {
         private readonly bool _hasItem;
@@ -19,12 +19,6 @@ namespace Funcky.Monads
             _item = item;
             _hasItem = true;
         }
-
-        [Pure]
-        public static bool operator ==(Option<TItem> lhs, Option<TItem> rhs) => lhs.Equals(rhs);
-
-        [Pure]
-        public static bool operator !=(Option<TItem> lhs, Option<TItem> rhs) => !lhs.Equals(rhs);
 
         [Pure]
         public static Option<TItem> None() => default;
@@ -71,20 +65,6 @@ namespace Funcky.Monads
                 none();
             }
         }
-
-        [Pure]
-        public override bool Equals(object obj)
-            => obj is Option<TItem> other && Equals(other);
-
-        [Pure]
-        public bool Equals(Option<TItem> other)
-            => Equals(_hasItem, other._hasItem) && Equals(_item, other._item);
-
-        [Pure]
-        public override int GetHashCode()
-            => Match(
-                 none: 0,
-                 some: item => item.GetHashCode());
 
         [Pure]
         public override string ToString()

--- a/Funcky/Monads/Option/Option.Equality.cs
+++ b/Funcky/Monads/Option/Option.Equality.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Diagnostics.Contracts;
+
+namespace Funcky.Monads
+{
+    public readonly partial struct Option<TItem> : IEquatable<Option<TItem>>
+    {
+        [Pure]
+        public static bool operator ==(Option<TItem> lhs, Option<TItem> rhs) => lhs.Equals(rhs);
+
+        [Pure]
+        public static bool operator !=(Option<TItem> lhs, Option<TItem> rhs) => !lhs.Equals(rhs);
+
+        [Pure]
+        public override bool Equals(object obj)
+            => obj is Option<TItem> other && Equals(other);
+
+        [Pure]
+        public bool Equals(Option<TItem> other)
+            => Equals(_hasItem, other._hasItem) && Equals(_item, other._item);
+
+        [Pure]
+        public override int GetHashCode()
+            => Match(
+                none: 0,
+                some: item => item.GetHashCode());
+    }
+}

--- a/Funcky/Monads/Result/Result.Core.cs
+++ b/Funcky/Monads/Result/Result.Core.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.Contracts;
 
 namespace Funcky.Monads
 {
-    public readonly partial struct Result<TValidResult>
+    public readonly partial struct Result<TValidResult> : IEquatable<Result<TValidResult>>
     {
         private const int SkipLowestStackFrame = 1;
 
@@ -71,9 +71,12 @@ namespace Funcky.Monads
 
         [Pure]
         public override bool Equals(object obj)
-            => obj is Result<TValidResult> other
-                 && Equals(_result, other._result)
-                 && Equals(_error, other._error);
+            => obj is Result<TValidResult> other && Equals(other);
+
+        [Pure]
+        public bool Equals(Result<TValidResult> other)
+            => Equals(_result, other._result)
+               && Equals(_error, other._error);
 
         [Pure]
         public override int GetHashCode()

--- a/Funcky/Unit.cs
+++ b/Funcky/Unit.cs
@@ -12,6 +12,18 @@ namespace Funcky
         public static bool operator !=(Unit lhs, Unit rhs) => false;
 
         [Pure]
+        public static bool operator <(Unit lhs, Unit rhs) => false;
+
+        [Pure]
+        public static bool operator <=(Unit lhs, Unit rhs) => true;
+
+        [Pure]
+        public static bool operator >(Unit lhs, Unit rhs) => false;
+
+        [Pure]
+        public static bool operator >=(Unit lhs, Unit rhs) => true;
+
+        [Pure]
         public bool Equals(Unit other) => true;
 
         [Pure]

--- a/changelog.md
+++ b/changelog.md
@@ -49,3 +49,6 @@
 * Move `ToEnumerable` extension method to its own class.
   This is only a breaking change if you've used the extension method as normal method.
   In that case you need to change `EnumerableExtensions.ToEnumerable` to `ObjectExtensions.ToEnumerable`.
+* Implement `IEquatable` on `Option`, `Result` and `Either`.
+* Fix incorrect `Equals` implementation on `Option`.
+  `Equals` previously returned `true` when comparing a `None` value with a `Some` value containing the default value of the type.


### PR DESCRIPTION
* Implement `IEquatable` on `Option`, `Result` and `Either`.
* Fix incorrect `Equals` implementation on `Option`.
  `Equals` previously returned `true` when comparing a `None` value with a `Some` value containing the default value of the type.