### PR TITLE
Create TheoryData directly from an IEnumerable

### DIFF
--- a/Funcky.Test/Extensions/ToTheoryDataExtensionTest.cs
+++ b/Funcky.Test/Extensions/ToTheoryDataExtensionTest.cs
@@ -13,10 +13,8 @@ namespace Funcky.Test.Extensions
 
         [Theory]
         [MemberData(nameof(TheoryFromEnumerable))]
-        public void GivenAnEnumerableEachElementCreatesATest(int index)
-        {
+        public void GivenAnEnumerableEachElementCreatesATest(int index) =>
             Assert.InRange(index, 0, 9);
-        }
 
         public static TheoryData<int> TheoryFromEnumerable()
             => Enumerable.Range(0, 10).ToTheoryData();

--- a/Funcky.Test/Extensions/ToTheoryDataExtensionTest.cs
+++ b/Funcky.Test/Extensions/ToTheoryDataExtensionTest.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Funcky.Xunit;
+using Xunit;
+
+namespace Funcky.Test.Extensions
+{
+    public class ToTheoryDataExtensionTest
+    {
+        private const string StringValue = "Hello world!";
+        private const int IntValue = 1337;
+
+        [Theory]
+        [MemberData(nameof(TheoryFromEnumerable))]
+        public void GivenAnEnumerableEachElementCreatesATest(int index)
+        {
+            Assert.InRange(index, 0, 9);
+        }
+
+        public static TheoryData<int> TheoryFromEnumerable()
+            => Enumerable.Range(0, 10).ToTheoryData();
+
+        [Theory]
+        [MemberData(nameof(TheoryFromRepeat))]
+        public void GivenAEnumberableOfTupleWeGetAllValues(int id, string value)
+        {
+            Assert.Equal(IntValue, id);
+            Assert.Equal(StringValue, value);
+        }
+
+        public static TheoryData<int, string> TheoryFromRepeat()
+            => Enumerable.Repeat(Tuple.Create(IntValue, StringValue), 1).ToTheoryData();
+    }
+}

--- a/Funcky.Xunit/Extensions/ToTheoryDataExtension.cs
+++ b/Funcky.Xunit/Extensions/ToTheoryDataExtension.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 using System.Linq;
 using Xunit;
 
@@ -7,66 +8,87 @@ namespace Funcky.Xunit
 {
     public static class ToTheoryDataExtension
     {
+        [Pure]
         public static TheoryData<T1> ToTheoryData<T1>(this IEnumerable<T1> enumerable)
             => enumerable.Aggregate(new TheoryData<T1>(), AddElementToTheoryData);
 
+        [Pure]
         public static TheoryData<T1> ToTheoryData<T1>(this IEnumerable<Tuple<T1>> enumerable)
             => enumerable.Aggregate(new TheoryData<T1>(), AddElementToTheoryData);
 
+        [Pure]
         public static TheoryData<T1, T2> ToTheoryData<T1, T2>(this IEnumerable<Tuple<T1, T2>> enumerable)
             => enumerable.Aggregate(new TheoryData<T1, T2>(), AddElementToTheoryData);
 
+        [Pure]
         public static TheoryData<T1, T2, T3> ToTheoryData<T1, T2, T3>(this IEnumerable<Tuple<T1, T2, T3>> enumerable)
             => enumerable.Aggregate(new TheoryData<T1, T2, T3>(), AddElementToTheoryData);
 
+        [Pure]
         public static TheoryData<T1, T2, T3, T4> ToTheoryData<T1, T2, T3, T4>(this IEnumerable<Tuple<T1, T2, T3, T4>> enumerable)
             => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4>(), AddElementToTheoryData);
 
+        [Pure]
         public static TheoryData<T1, T2, T3, T4, T5> ToTheoryData<T1, T2, T3, T4, T5>(this IEnumerable<Tuple<T1, T2, T3, T4, T5>> enumerable)
             => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5>(), AddElementToTheoryData);
 
+        [Pure]
         public static TheoryData<T1, T2, T3, T4, T5, T6> ToTheoryData<T1, T2, T3, T4, T5, T6>(this IEnumerable<Tuple<T1, T2, T3, T4, T5, T6>> enumerable)
             => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5, T6>(), AddElementToTheoryData);
 
+        [Pure]
         public static TheoryData<T1, T2, T3, T4, T5, T6, T7> ToTheoryData<T1, T2, T3, T4, T5, T6, T7>(this IEnumerable<Tuple<T1, T2, T3, T4, T5, T6, T7>> enumerable)
             => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5, T6, T7>(), AddElementToTheoryData);
 
+        [Pure]
         public static TheoryData<T1, T2, T3, T4, T5, T6, T7, T8> ToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8>(this IEnumerable<Tuple<T1, T2, T3, T4, T5, T6, T7, T8>> enumerable)
             => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5, T6, T7, T8>(), AddElementToTheoryData);
 
+        [Pure]
         public static TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9> ToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this IEnumerable<Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9>>> enumerable)
             => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9>(), AddElementToTheoryData);
 
+        [Pure]
         public static TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> ToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this IEnumerable<Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>>> enumerable)
             => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(), AddElementToTheoryData);
 
+        [Pure]
         public static TheoryData<T1> ToTheoryData<T1>(this IEnumerable<ValueTuple<T1>> enumerable)
             => enumerable.Aggregate(new TheoryData<T1>(), AddElementToTheoryData);
 
+        [Pure]
         public static TheoryData<T1, T2> ToTheoryData<T1, T2>(this IEnumerable<(T1 Item1, T2 Item2)> enumerable)
             => enumerable.Aggregate(new TheoryData<T1, T2>(), AddElementToTheoryData);
 
+        [Pure]
         public static TheoryData<T1, T2, T3> ToTheoryData<T1, T2, T3>(this IEnumerable<(T1 Item1, T2 Item2, T3 Item3)> enumerable)
             => enumerable.Aggregate(new TheoryData<T1, T2, T3>(), AddElementToTheoryData);
 
+        [Pure]
         public static TheoryData<T1, T2, T3, T4> ToTheoryData<T1, T2, T3, T4>(this IEnumerable<(T1 Item1, T2 Item2, T3 Item3, T4 Item4)> enumerable)
             => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4>(), AddElementToTheoryData);
 
+        [Pure]
         public static TheoryData<T1, T2, T3, T4, T5> ToTheoryData<T1, T2, T3, T4, T5>(this IEnumerable<(T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5)> enumerable)
             => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5>(), AddElementToTheoryData);
 
+        [Pure]
         public static TheoryData<T1, T2, T3, T4, T5, T6> ToTheoryData<T1, T2, T3, T4, T5, T6>(this IEnumerable<(T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5, T6 Item6)> enumerable)
             => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5, T6>(), AddElementToTheoryData);
 
+        [Pure]
         public static TheoryData<T1, T2, T3, T4, T5, T6, T7> ToTheoryData<T1, T2, T3, T4, T5, T6, T7>(this IEnumerable<(T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5, T6 Item6, T7 Item7)> enumerable)
             => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5, T6, T7>(), AddElementToTheoryData);
 
+        [Pure]
         public static TheoryData<T1, T2, T3, T4, T5, T6, T7, T8> ToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8>(this IEnumerable<(T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5, T6 Item6, T7 Item7, T8 Item8)> enumerable)
             => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5, T6, T7, T8>(), AddElementToTheoryData);
 
+        [Pure]
         public static TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9> ToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this IEnumerable<(T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5, T6 Item6, T7 Item7, T8 Item8, T9 Item9)> enumerable)
             => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9>(), AddElementToTheoryData);
 
+        [Pure]
         public static TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> ToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this IEnumerable<(T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5, T6 Item6, T7 Item7, T8 Item8, T9 Item9, T10 Item10)> enumerable)
             => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(), AddElementToTheoryData);
 

--- a/Funcky.Xunit/Extensions/ToTheoryDataExtension.cs
+++ b/Funcky.Xunit/Extensions/ToTheoryDataExtension.cs
@@ -40,6 +40,36 @@ namespace Funcky.Xunit
         public static TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> ToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this IEnumerable<Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>>> enumerable)
             => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(), AddElementToTheoryData);
 
+        public static TheoryData<T1> ToTheoryData<T1>(this IEnumerable<ValueTuple<T1>> enumerable)
+            => enumerable.Aggregate(new TheoryData<T1>(), AddElementToTheoryData);
+
+        public static TheoryData<T1, T2> ToTheoryData<T1, T2>(this IEnumerable<(T1 Item1, T2 Item2)> enumerable)
+            => enumerable.Aggregate(new TheoryData<T1, T2>(), AddElementToTheoryData);
+
+        public static TheoryData<T1, T2, T3> ToTheoryData<T1, T2, T3>(this IEnumerable<(T1 Item1, T2 Item2, T3 Item3)> enumerable)
+            => enumerable.Aggregate(new TheoryData<T1, T2, T3>(), AddElementToTheoryData);
+
+        public static TheoryData<T1, T2, T3, T4> ToTheoryData<T1, T2, T3, T4>(this IEnumerable<(T1 Item1, T2 Item2, T3 Item3, T4 Item4)> enumerable)
+            => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4>(), AddElementToTheoryData);
+
+        public static TheoryData<T1, T2, T3, T4, T5> ToTheoryData<T1, T2, T3, T4, T5>(this IEnumerable<(T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5)> enumerable)
+            => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5>(), AddElementToTheoryData);
+
+        public static TheoryData<T1, T2, T3, T4, T5, T6> ToTheoryData<T1, T2, T3, T4, T5, T6>(this IEnumerable<(T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5, T6 Item6)> enumerable)
+            => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5, T6>(), AddElementToTheoryData);
+
+        public static TheoryData<T1, T2, T3, T4, T5, T6, T7> ToTheoryData<T1, T2, T3, T4, T5, T6, T7>(this IEnumerable<(T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5, T6 Item6, T7 Item7)> enumerable)
+            => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5, T6, T7>(), AddElementToTheoryData);
+
+        public static TheoryData<T1, T2, T3, T4, T5, T6, T7, T8> ToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8>(this IEnumerable<(T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5, T6 Item6, T7 Item7, T8 Item8)> enumerable)
+            => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5, T6, T7, T8>(), AddElementToTheoryData);
+
+        public static TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9> ToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this IEnumerable<(T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5, T6 Item6, T7 Item7, T8 Item8, T9 Item9)> enumerable)
+            => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9>(), AddElementToTheoryData);
+
+        public static TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> ToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this IEnumerable<(T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5, T6 Item6, T7 Item7, T8 Item8, T9 Item9, T10 Item10)> enumerable)
+            => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(), AddElementToTheoryData);
+
         private static TheoryData<T1> AddElementToTheoryData<T1>(TheoryData<T1> theoryData, T1 element)
         {
             theoryData.Add(element);
@@ -113,6 +143,76 @@ namespace Funcky.Xunit
         private static TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> AddElementToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> theoryData, Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>> tuple)
         {
             theoryData.Add(tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4, tuple.Item5, tuple.Item6, tuple.Item7, tuple.Rest.Item1, tuple.Rest.Item2, tuple.Rest.Item3);
+
+            return theoryData;
+        }
+
+        private static TheoryData<T1> AddElementToTheoryData<T1>(TheoryData<T1> theoryData, ValueTuple<T1> tuple)
+        {
+            theoryData.Add(tuple.Item1);
+
+            return theoryData;
+        }
+
+        private static TheoryData<T1, T2> AddElementToTheoryData<T1, T2>(TheoryData<T1, T2> theoryData, (T1 Item1, T2 Item2) tuple)
+        {
+            theoryData.Add(tuple.Item1, tuple.Item2);
+
+            return theoryData;
+        }
+
+        private static TheoryData<T1, T2, T3> AddElementToTheoryData<T1, T2, T3>(TheoryData<T1, T2, T3> theoryData, (T1 Item1, T2 Item2, T3 Item3) tuple)
+        {
+            theoryData.Add(tuple.Item1, tuple.Item2, tuple.Item3);
+
+            return theoryData;
+        }
+
+        private static TheoryData<T1, T2, T3, T4> AddElementToTheoryData<T1, T2, T3, T4>(TheoryData<T1, T2, T3, T4> theoryData, (T1 Item1, T2 Item2, T3 Item3, T4 Item4) tuple)
+        {
+            theoryData.Add(tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4);
+
+            return theoryData;
+        }
+
+        private static TheoryData<T1, T2, T3, T4, T5> AddElementToTheoryData<T1, T2, T3, T4, T5>(TheoryData<T1, T2, T3, T4, T5> theoryData, (T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5) tuple)
+        {
+            theoryData.Add(tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4, tuple.Item5);
+
+            return theoryData;
+        }
+
+        private static TheoryData<T1, T2, T3, T4, T5, T6> AddElementToTheoryData<T1, T2, T3, T4, T5, T6>(TheoryData<T1, T2, T3, T4, T5, T6> theoryData, (T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5, T6 Item6) tuple)
+        {
+            theoryData.Add(tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4, tuple.Item5, tuple.Item6);
+
+            return theoryData;
+        }
+
+        private static TheoryData<T1, T2, T3, T4, T5, T6, T7> AddElementToTheoryData<T1, T2, T3, T4, T5, T6, T7>(TheoryData<T1, T2, T3, T4, T5, T6, T7> theoryData, (T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5, T6 Item6, T7 Item7) tuple)
+        {
+            theoryData.Add(tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4, tuple.Item5, tuple.Item6, tuple.Item7);
+
+            return theoryData;
+        }
+
+        private static TheoryData<T1, T2, T3, T4, T5, T6, T7, T8> AddElementToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8>(TheoryData<T1, T2, T3, T4, T5, T6, T7, T8> theoryData, (T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5, T6 Item6, T7 Item7, T8 Item8) tuple)
+        {
+            theoryData.Add(tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4, tuple.Item5, tuple.Item6, tuple.Item7, tuple.Item8);
+
+            return theoryData;
+        }
+
+        private static TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9> AddElementToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9>(TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9> theoryData, (T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5, T6 Item6, T7 Item7, T8 Item8, T9 Item9) tuple)
+        {
+            theoryData.Add(tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4, tuple.Item5, tuple.Item6, tuple.Item7, tuple.Item8, tuple.Item9);
+
+            return theoryData;
+        }
+
+        private static TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> AddElementToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> theoryData, (T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5, T6 Item6, T7 Item7, T8 Item8, T9 Item9, T10 Item10) tuple)
+        {
+            theoryData.Add(tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4, tuple.Item5, tuple.Item6, tuple.Item7, tuple.Item8, tuple.Item9, tuple.Item10);
 
             return theoryData;
         }

--- a/Funcky.Xunit/Extensions/ToTheoryDataExtension.cs
+++ b/Funcky.Xunit/Extensions/ToTheoryDataExtension.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Funcky.Xunit
+{
+    public static class ToTheoryDataExtension
+    {
+        public static TheoryData<T1> ToTheoryData<T1>(this IEnumerable<T1> enumerable)
+            => enumerable.Aggregate(new TheoryData<T1>(), AddElementToTheoryData);
+
+        public static TheoryData<T1, T2> ToTheoryData<T1, T2>(this IEnumerable<Tuple<T1, T2>> enumerable)
+            => enumerable.Aggregate(new TheoryData<T1, T2>(), AddElementToTheoryData);
+
+        public static TheoryData<T1, T2, T3> ToTheoryData<T1, T2, T3>(this IEnumerable<Tuple<T1, T2, T3>> enumerable)
+            => enumerable.Aggregate(new TheoryData<T1, T2, T3>(), AddElementToTheoryData);
+
+        public static TheoryData<T1, T2, T3, T4> ToTheoryData<T1, T2, T3, T4>(this IEnumerable<Tuple<T1, T2, T3, T4>> enumerable)
+            => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4>(), AddElementToTheoryData);
+
+        public static TheoryData<T1, T2, T3, T4, T5> ToTheoryData<T1, T2, T3, T4, T5>(this IEnumerable<Tuple<T1, T2, T3, T4, T5>> enumerable)
+            => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5>(), AddElementToTheoryData);
+
+        public static TheoryData<T1, T2, T3, T4, T5, T6> ToTheoryData<T1, T2, T3, T4, T5, T6>(this IEnumerable<Tuple<T1, T2, T3, T4, T5, T6>> enumerable)
+            => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5, T6>(), AddElementToTheoryData);
+
+        public static TheoryData<T1, T2, T3, T4, T5, T6, T7> ToTheoryData<T1, T2, T3, T4, T5, T6, T7>(this IEnumerable<Tuple<T1, T2, T3, T4, T5, T6, T7>> enumerable)
+            => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5, T6, T7>(), AddElementToTheoryData);
+
+        public static TheoryData<T1, T2, T3, T4, T5, T6, T7, T8> ToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8>(this IEnumerable<Tuple<T1, T2, T3, T4, T5, T6, T7, T8>> enumerable)
+            => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5, T6, T7, T8>(), AddElementToTheoryData);
+
+        public static TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9> ToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this IEnumerable<Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9>>> enumerable)
+            => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9>(), AddElementToTheoryData);
+
+        public static TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> ToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this IEnumerable<Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>>> enumerable)
+            => enumerable.Aggregate(new TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(), AddElementToTheoryData);
+
+        private static TheoryData<T1> AddElementToTheoryData<T1>(TheoryData<T1> theoryData, T1 element)
+        {
+            theoryData.Add(element);
+
+            return theoryData;
+        }
+
+        private static TheoryData<T1, T2> AddElementToTheoryData<T1, T2>(TheoryData<T1, T2> theoryData, Tuple<T1, T2> tuple)
+        {
+            theoryData.Add(tuple.Item1, tuple.Item2);
+
+            return theoryData;
+        }
+
+        private static TheoryData<T1, T2, T3> AddElementToTheoryData<T1, T2, T3>(TheoryData<T1, T2, T3> theoryData, Tuple<T1, T2, T3> tuple)
+        {
+            theoryData.Add(tuple.Item1, tuple.Item2, tuple.Item3);
+
+            return theoryData;
+        }
+
+        private static TheoryData<T1, T2, T3, T4> AddElementToTheoryData<T1, T2, T3, T4>(TheoryData<T1, T2, T3, T4> theoryData, Tuple<T1, T2, T3, T4> tuple)
+        {
+            theoryData.Add(tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4);
+
+            return theoryData;
+        }
+
+        private static TheoryData<T1, T2, T3, T4, T5> AddElementToTheoryData<T1, T2, T3, T4, T5>(TheoryData<T1, T2, T3, T4, T5> theoryData, Tuple<T1, T2, T3, T4, T5> tuple)
+        {
+            theoryData.Add(tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4, tuple.Item5);
+
+            return theoryData;
+        }
+
+        private static TheoryData<T1, T2, T3, T4, T5, T6> AddElementToTheoryData<T1, T2, T3, T4, T5, T6>(TheoryData<T1, T2, T3, T4, T5, T6> theoryData, Tuple<T1, T2, T3, T4, T5, T6> tuple)
+        {
+            theoryData.Add(tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4, tuple.Item5, tuple.Item6);
+
+            return theoryData;
+        }
+
+        private static TheoryData<T1, T2, T3, T4, T5, T6, T7> AddElementToTheoryData<T1, T2, T3, T4, T5, T6, T7>(TheoryData<T1, T2, T3, T4, T5, T6, T7> theoryData, Tuple<T1, T2, T3, T4, T5, T6, T7> tuple)
+        {
+            theoryData.Add(tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4, tuple.Item5, tuple.Item6, tuple.Item7);
+
+            return theoryData;
+        }
+
+        private static TheoryData<T1, T2, T3, T4, T5, T6, T7, T8> AddElementToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8>(TheoryData<T1, T2, T3, T4, T5, T6, T7, T8> theoryData, Tuple<T1, T2, T3, T4, T5, T6, T7, T8> tuple)
+        {
+            theoryData.Add(tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4, tuple.Item5, tuple.Item6, tuple.Item7, tuple.Rest);
+
+            return theoryData;
+        }
+
+        private static TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9> AddElementToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9>(TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9> theoryData, Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9>> tuple)
+        {
+            theoryData.Add(tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4, tuple.Item5, tuple.Item6, tuple.Item7, tuple.Rest.Item1, tuple.Rest.Item2);
+
+            return theoryData;
+        }
+
+        private static TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> AddElementToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> theoryData, Tuple<T1, T2, T3, T4, T5, T6, T7, Tuple<T8, T9, T10>> tuple)
+        {
+            theoryData.Add(tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4, tuple.Item5, tuple.Item6, tuple.Item7, tuple.Rest.Item1, tuple.Rest.Item2, tuple.Rest.Item3);
+
+            return theoryData;
+        }
+    }
+}

--- a/Funcky.Xunit/Extensions/ToTheoryDataExtension.cs
+++ b/Funcky.Xunit/Extensions/ToTheoryDataExtension.cs
@@ -10,6 +10,9 @@ namespace Funcky.Xunit
         public static TheoryData<T1> ToTheoryData<T1>(this IEnumerable<T1> enumerable)
             => enumerable.Aggregate(new TheoryData<T1>(), AddElementToTheoryData);
 
+        public static TheoryData<T1> ToTheoryData<T1>(this IEnumerable<Tuple<T1>> enumerable)
+            => enumerable.Aggregate(new TheoryData<T1>(), AddElementToTheoryData);
+
         public static TheoryData<T1, T2> ToTheoryData<T1, T2>(this IEnumerable<Tuple<T1, T2>> enumerable)
             => enumerable.Aggregate(new TheoryData<T1, T2>(), AddElementToTheoryData);
 
@@ -40,6 +43,13 @@ namespace Funcky.Xunit
         private static TheoryData<T1> AddElementToTheoryData<T1>(TheoryData<T1> theoryData, T1 element)
         {
             theoryData.Add(element);
+
+            return theoryData;
+        }
+
+        private static TheoryData<T1> AddElementToTheoryData<T1>(TheoryData<T1> theoryData, Tuple<T1> tuple)
+        {
+            theoryData.Add(tuple.Item1);
 
             return theoryData;
         }

--- a/Funcky.Xunit/Funcky.Xunit.csproj
+++ b/Funcky.Xunit/Funcky.Xunit.csproj
@@ -23,7 +23,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="xunit.assert" Version="2.4.0" />
-        <PackageReference Include="xunit.core" Version="2.4.0" />
+        <PackageReference Include="xunit.extensibility.core" Version="2.4.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../Funcky/Funcky.csproj" />

--- a/Funcky.Xunit/Funcky.Xunit.csproj
+++ b/Funcky.Xunit/Funcky.Xunit.csproj
@@ -23,6 +23,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="xunit.assert" Version="2.4.0" />
+        <PackageReference Include="xunit.core" Version="2.4.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../Funcky/Funcky.csproj" />

--- a/changelog.md
+++ b/changelog.md
@@ -86,3 +86,5 @@
 
 ## Unreleased
 * Add `Inspect` method to `Option` akin to `IEnumerable.Inspect`.
+* Add `ToTheoryData` extension for `IEnumerable<T>` for xUnit.
+


### PR DESCRIPTION
When working with Enumerables and Linq, this Extension Method allows the generation of TheoryData from an IEnumerable directly.