### PR TITLE
Explicitly target .NET Core 3.1

### DIFF
--- a/Funcky/Extensions/StringExtensions.cs
+++ b/Funcky/Extensions/StringExtensions.cs
@@ -20,7 +20,7 @@ namespace Funcky.Extensions
         public static Option<int> IndexOfOrNone(this string haystack, char value, int startIndex, int count)
             => MapIndexToOption(haystack.IndexOf(value, startIndex, count));
 
-#if NETSTANDARD2_1 || NETCOREAPP3_1
+#if INDEXOF_CHAR_COMPARISONTYPE_SUPPORTED
         public static Option<int> IndexOfOrNone(this string haystack, char value, StringComparison comparisonType)
             => MapIndexToOption(haystack.IndexOf(value, comparisonType));
 #endif

--- a/Funcky/Extensions/StringExtensions.cs
+++ b/Funcky/Extensions/StringExtensions.cs
@@ -20,7 +20,7 @@ namespace Funcky.Extensions
         public static Option<int> IndexOfOrNone(this string haystack, char value, int startIndex, int count)
             => MapIndexToOption(haystack.IndexOf(value, startIndex, count));
 
-#if NETSTANDARD2_1
+#if NETSTANDARD2_1 || NETCOREAPP3_1
         public static Option<int> IndexOfOrNone(this string haystack, char value, StringComparison comparisonType)
             => MapIndexToOption(haystack.IndexOf(value, comparisonType));
 #endif

--- a/Funcky/Funcky.csproj
+++ b/Funcky/Funcky.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>8.0</LangVersion>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Funcky/Funcky.csproj
+++ b/Funcky/Funcky.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
         <LangVersion>8.0</LangVersion>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Funcky/Funcky.csproj
+++ b/Funcky/Funcky.csproj
@@ -14,9 +14,12 @@
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netcoreapp3.1'">
+        <DefineConstants>$(DefineConstants);INDEXOF_CHAR_COMPARISONTYPE_SUPPORTED;TIMESPAN_MULTIPLY_SUPPORTED</DefineConstants>
+    </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[1.1.1, 2)" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-        <PackageReference Include="System.Collections.Immutable" Version="[1.7.1, 2)"  Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1'" />
+        <PackageReference Include="System.Collections.Immutable" Version="[1.7.1, 2)" Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1'" />
         <PackageReference Include="ConfigureAwait.Fody" Version="3.3.1" PrivateAssets="all" />
         <PackageReference Include="Fody" Version="6.2.6" PrivateAssets="all" />
     </ItemGroup>

--- a/Funcky/Functional/RetryPolicies/ExponentialBackoffRetryPolicy.cs
+++ b/Funcky/Functional/RetryPolicies/ExponentialBackoffRetryPolicy.cs
@@ -23,6 +23,6 @@ namespace Funcky
             => TimeSpan.FromTicks((long)(_firstDelay.Ticks * Exponential(onRetryCount)));
 #endif
 
-        private double Exponential(int onRetryCount) => Math.Pow(BaseFactor, onRetryCount);
+        private static double Exponential(int onRetryCount) => Math.Pow(BaseFactor, onRetryCount);
     }
 }

--- a/Funcky/Functional/RetryPolicies/ExponentialBackoffRetryPolicy.cs
+++ b/Funcky/Functional/RetryPolicies/ExponentialBackoffRetryPolicy.cs
@@ -17,7 +17,7 @@ namespace Funcky
 
 #if TIMESPAN_MULTIPLY_SUPPORTED
         public TimeSpan Duration(int onRetryCount)
-            => _firstDelay.Multiply(Exponential(onRetryCount));
+            => _firstDelay * Exponential(onRetryCount);
 #else
         public TimeSpan Duration(int onRetryCount)
             => TimeSpan.FromTicks((long)(_firstDelay.Ticks * Exponential(onRetryCount)));

--- a/Funcky/Functional/RetryPolicies/ExponentialBackoffRetryPolicy.cs
+++ b/Funcky/Functional/RetryPolicies/ExponentialBackoffRetryPolicy.cs
@@ -15,7 +15,7 @@ namespace Funcky
 
         public int MaxRetries { get; }
 
-#if NETSTANDARD2_1
+#if TIMESPAN_MULTIPLY_SUPPORTED
         public TimeSpan Duration(int onRetryCount)
             => _firstDelay.Multiply(Exponential(onRetryCount));
 #else

--- a/Funcky/Functional/RetryPolicies/LinearBackoffRetryPolicy.cs
+++ b/Funcky/Functional/RetryPolicies/LinearBackoffRetryPolicy.cs
@@ -14,7 +14,7 @@ namespace Funcky
 
         public int MaxRetries { get; }
 
-#if NETSTANDARD2_1
+#if TIMESPAN_MULTIPLY_SUPPORTED
         public TimeSpan Duration(int onRetryCount)
             => _firstDelay.Multiply(onRetryCount);
 #else

--- a/Funcky/Functional/RetryPolicies/LinearBackoffRetryPolicy.cs
+++ b/Funcky/Functional/RetryPolicies/LinearBackoffRetryPolicy.cs
@@ -16,7 +16,7 @@ namespace Funcky
 
 #if TIMESPAN_MULTIPLY_SUPPORTED
         public TimeSpan Duration(int onRetryCount)
-            => _firstDelay.Multiply(onRetryCount);
+            => _firstDelay * onRetryCount;
 #else
         public TimeSpan Duration(int onRetryCount)
             => TimeSpan.FromTicks(_firstDelay.Ticks * onRetryCount);

--- a/Funcky/Monads/Either/Either.Core.cs
+++ b/Funcky/Monads/Either/Either.Core.cs
@@ -72,7 +72,7 @@ namespace Funcky.Monads
             };
 
         [Pure]
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is Either<TLeft, TRight> other && Equals(other);
 
         [Pure]

--- a/Funcky/Monads/ExceptionUtilities.cs
+++ b/Funcky/Monads/ExceptionUtilities.cs
@@ -6,9 +6,9 @@ namespace Funcky.Monads
 {
     internal static class ExceptionUtilities
     {
-        private static readonly FieldInfo StackTraceField = typeof(Exception).GetField("_stackTraceString", BindingFlags.NonPublic | BindingFlags.Instance);
-        private static readonly Type TraceFormatType = Type.GetType("System.Diagnostics.StackTrace").GetNestedType("TraceFormat", BindingFlags.NonPublic);
-        private static readonly MethodInfo TraceToStringMethodInfo = typeof(StackTrace).GetMethod("ToString", BindingFlags.NonPublic | BindingFlags.Instance, null, new[] { TraceFormatType }, null);
+        private static readonly FieldInfo StackTraceField = typeof(Exception).GetField("_stackTraceString", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        private static readonly Type TraceFormatType = Type.GetType("System.Diagnostics.StackTrace")!.GetNestedType("TraceFormat", BindingFlags.NonPublic)!;
+        private static readonly MethodInfo TraceToStringMethodInfo = typeof(StackTrace).GetMethod("ToString", BindingFlags.NonPublic | BindingFlags.Instance, null, new[] { TraceFormatType }, null)!;
 
         public static Exception SetStackTrace(this Exception target, StackTrace stack)
         {

--- a/Funcky/Monads/Option/Option.Equality.cs
+++ b/Funcky/Monads/Option/Option.Equality.cs
@@ -12,7 +12,7 @@ namespace Funcky.Monads
         public static bool operator !=(Option<TItem> lhs, Option<TItem> rhs) => !lhs.Equals(rhs);
 
         [Pure]
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is Option<TItem> other && Equals(other);
 
         [Pure]

--- a/Funcky/Monads/Result/Result.Core.cs
+++ b/Funcky/Monads/Result/Result.Core.cs
@@ -70,7 +70,7 @@ namespace Funcky.Monads
         }
 
         [Pure]
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is Result<TValidResult> other && Equals(other);
 
         [Pure]

--- a/Funcky/Unit.cs
+++ b/Funcky/Unit.cs
@@ -30,7 +30,7 @@ namespace Funcky
         public bool Equals(Unit other) => true;
 
         [Pure]
-        public override bool Equals(object obj) => obj is Unit other && Equals(other);
+        public override bool Equals(object? obj) => obj is Unit other && Equals(other);
 
         [Pure]
         public override int GetHashCode() => 0;


### PR DESCRIPTION
That way, consumers who use netcoreapp3.1 don't need the dependency on System.Collections.Immutable because its in the framework.