### PR TITLE
Move retry policies

### DIFF
--- a/Funcky.Test/FunctionalClass/RetryAsyncTest.cs
+++ b/Funcky.Test/FunctionalClass/RetryAsyncTest.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Funcky.Monads;
+using Funcky.RetryPolicies;
 using Funcky.Test.TestUtils;
 using Funcky.Xunit;
 using Xunit;

--- a/Funcky.Test/FunctionalClass/RetryTest.cs
+++ b/Funcky.Test/FunctionalClass/RetryTest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Funcky.Monads;
+using Funcky.RetryPolicies;
 using Funcky.Test.TestUtils;
 using Xunit;
 using static Funcky.Functional;

--- a/Funcky/Functional/Retry.cs
+++ b/Funcky/Functional/Retry.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Funcky.Monads;
+using Funcky.RetryPolicies;
 using static System.Threading.Thread;
 
 namespace Funcky

--- a/Funcky/PublicAPI.Shipped.txt
+++ b/Funcky/PublicAPI.Shipped.txt
@@ -1,18 +1,6 @@
 #nullable enable
 
 ~Funcky.GenericConstraints.RequireClass<T>
-Funcky.ConstantDelayPolicy
-Funcky.ConstantDelayPolicy.ConstantDelayPolicy(int maxRetry, System.TimeSpan delay) -> void
-Funcky.ConstantDelayPolicy.Duration(int onRetryCount) -> System.TimeSpan
-Funcky.ConstantDelayPolicy.MaxRetries.get -> int
-Funcky.DoNotRetryPolicy
-Funcky.DoNotRetryPolicy.DoNotRetryPolicy() -> void
-Funcky.DoNotRetryPolicy.Duration(int onRetryCount) -> System.TimeSpan
-Funcky.DoNotRetryPolicy.MaxRetries.get -> int
-Funcky.ExponentialBackoffRetryPolicy
-Funcky.ExponentialBackoffRetryPolicy.Duration(int onRetryCount) -> System.TimeSpan
-Funcky.ExponentialBackoffRetryPolicy.ExponentialBackoffRetryPolicy(int maxRetry, System.TimeSpan firstDelay) -> void
-Funcky.ExponentialBackoffRetryPolicy.MaxRetries.get -> int
 Funcky.Extensions.AsyncEnumerableExtensions
 Funcky.Extensions.DictionaryExtensions
 Funcky.Extensions.EnumerableExtensions
@@ -41,13 +29,6 @@ Funcky.Functional
 Funcky.GenericConstraints.RequireClass<T>.RequireClass() -> void
 Funcky.GenericConstraints.RequireStruct<T>
 Funcky.GenericConstraints.RequireStruct<T>.RequireStruct() -> void
-Funcky.IRetryPolicy
-Funcky.IRetryPolicy.Duration(int onRetryCount) -> System.TimeSpan
-Funcky.IRetryPolicy.MaxRetries.get -> int
-Funcky.LinearBackoffRetryPolicy
-Funcky.LinearBackoffRetryPolicy.Duration(int onRetryCount) -> System.TimeSpan
-Funcky.LinearBackoffRetryPolicy.LinearBackoffRetryPolicy(int maxRetry, System.TimeSpan firstDelay) -> void
-Funcky.LinearBackoffRetryPolicy.MaxRetries.get -> int
 Funcky.Monads.AwaitableOptionExtensions
 Funcky.Monads.Either<TLeft, TRight>
 Funcky.Monads.Either<TLeft, TRight>.Equals(Funcky.Monads.Either<TLeft, TRight> other) -> bool
@@ -93,8 +74,6 @@ Funcky.Monads.Result<TValidResult>.Match(System.Action<TValidResult>! ok, System
 Funcky.Monads.Result<TValidResult>.Match<TMatchResult>(System.Func<TValidResult, TMatchResult>! ok, System.Func<System.Exception!, TMatchResult>! error) -> TMatchResult
 Funcky.Monads.Result<TValidResult>.Select<TResult>(System.Func<TValidResult, TResult>! selector) -> Funcky.Monads.Result<TResult>
 Funcky.Monads.Result<TValidResult>.SelectMany<TSelectedResult, TResult>(System.Func<TValidResult, Funcky.Monads.Result<TSelectedResult>>! selectedResultSelector, System.Func<TValidResult, TSelectedResult, TResult>! resultSelector) -> Funcky.Monads.Result<TResult>
-Funcky.NoDelayRetryPolicy
-Funcky.NoDelayRetryPolicy.NoDelayRetryPolicy(int maxRetry) -> void
 Funcky.Sequence
 Funcky.Unit
 Funcky.Unit.CompareTo(Funcky.Unit other) -> int
@@ -297,8 +276,6 @@ static Funcky.Functional.NoOperation<T1, T2>(T1 p1, T2 p2) -> void
 static Funcky.Functional.NoOperation<T1>(T1 p1) -> void
 static Funcky.Functional.Not<T>(System.Func<T, bool>! predicate) -> System.Func<T, bool>!
 static Funcky.Functional.Retry<TResult>(System.Func<Funcky.Monads.Option<TResult>>! producer) -> TResult
-static Funcky.Functional.Retry<TResult>(System.Func<Funcky.Monads.Option<TResult>>! producer, Funcky.IRetryPolicy! retryPolicy) -> Funcky.Monads.Option<TResult>
-static Funcky.Functional.RetryAsync<TResult>(System.Func<System.Threading.Tasks.Task<Funcky.Monads.Option<TResult>>!>! producer, Funcky.IRetryPolicy! retryPolicy) -> System.Threading.Tasks.Task<Funcky.Monads.Option<TResult>>!
 static Funcky.Functional.True<T>(T ω) -> bool
 static Funcky.Functional.Uncurry<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(System.Func<T1, System.Func<T2, System.Func<T3, System.Func<T4, System.Func<T5, System.Func<T6, System.Func<T7, System.Func<T8, TResult>!>!>!>!>!>!>!>! function) -> System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult>!
 static Funcky.Functional.Uncurry<T1, T2, T3, T4, T5, T6, T7, TResult>(System.Func<T1, System.Func<T2, System.Func<T3, System.Func<T4, System.Func<T5, System.Func<T6, System.Func<T7, TResult>!>!>!>!>!>!>! function) -> System.Func<T1, T2, T3, T4, T5, T6, T7, TResult>!

--- a/Funcky/PublicAPI.Unshipped.txt
+++ b/Funcky/PublicAPI.Unshipped.txt
@@ -1,10 +1,31 @@
-﻿#nullable enable
+#nullable enable
 Funcky.DataTypes.EitherOrBoth<TLeft, TRight>
 Funcky.DataTypes.EitherOrBoth<TLeft, TRight>.Equals(Funcky.DataTypes.EitherOrBoth<TLeft, TRight> other) -> bool
 Funcky.DataTypes.EitherOrBoth<TLeft, TRight>.Match(System.Action<TLeft>! left, System.Action<TRight>! right, System.Action<TLeft, TRight>! both) -> void
 Funcky.DataTypes.EitherOrBoth<TLeft, TRight>.Match<TMatchResult>(System.Func<TLeft, TMatchResult>! left, System.Func<TRight, TMatchResult>! right, System.Func<TLeft, TRight, TMatchResult>! both) -> TMatchResult
 Funcky.Extensions.FunctionCompositionExtensions
 Funcky.Monads.Either<TLeft, TRight>.Match(System.Action<TLeft>! left, System.Action<TRight>! right) -> void
+Funcky.RetryPolicies.ConstantDelayPolicy
+Funcky.RetryPolicies.ConstantDelayPolicy.ConstantDelayPolicy(int maxRetry, System.TimeSpan delay) -> void
+Funcky.RetryPolicies.ConstantDelayPolicy.Duration(int onRetryCount) -> System.TimeSpan
+Funcky.RetryPolicies.ConstantDelayPolicy.MaxRetries.get -> int
+Funcky.RetryPolicies.DoNotRetryPolicy
+Funcky.RetryPolicies.DoNotRetryPolicy.DoNotRetryPolicy() -> void
+Funcky.RetryPolicies.DoNotRetryPolicy.Duration(int onRetryCount) -> System.TimeSpan
+Funcky.RetryPolicies.DoNotRetryPolicy.MaxRetries.get -> int
+Funcky.RetryPolicies.ExponentialBackOffRetryPolicy
+Funcky.RetryPolicies.ExponentialBackOffRetryPolicy.Duration(int onRetryCount) -> System.TimeSpan
+Funcky.RetryPolicies.ExponentialBackOffRetryPolicy.ExponentialBackOffRetryPolicy(int maxRetry, System.TimeSpan firstDelay) -> void
+Funcky.RetryPolicies.ExponentialBackOffRetryPolicy.MaxRetries.get -> int
+Funcky.RetryPolicies.IRetryPolicy
+Funcky.RetryPolicies.IRetryPolicy.Duration(int onRetryCount) -> System.TimeSpan
+Funcky.RetryPolicies.IRetryPolicy.MaxRetries.get -> int
+Funcky.RetryPolicies.LinearBackoffRetryPolicy
+Funcky.RetryPolicies.LinearBackoffRetryPolicy.Duration(int onRetryCount) -> System.TimeSpan
+Funcky.RetryPolicies.LinearBackoffRetryPolicy.LinearBackoffRetryPolicy(int maxRetry, System.TimeSpan firstDelay) -> void
+Funcky.RetryPolicies.LinearBackoffRetryPolicy.MaxRetries.get -> int
+Funcky.RetryPolicies.NoDelayRetryPolicy
+Funcky.RetryPolicies.NoDelayRetryPolicy.NoDelayRetryPolicy(int maxRetry) -> void
 override Funcky.DataTypes.EitherOrBoth<TLeft, TRight>.Equals(object? obj) -> bool
 override Funcky.DataTypes.EitherOrBoth<TLeft, TRight>.GetHashCode() -> int
 static Funcky.DataTypes.EitherOrBoth<TLeft, TRight>.Both(TLeft left, TRight right) -> Funcky.DataTypes.EitherOrBoth<TLeft, TRight>
@@ -45,6 +66,8 @@ static Funcky.Extensions.ParseExtensions.ParseShortOrNone(this string! candidate
 static Funcky.Extensions.ParseExtensions.ParseTimeSpanOrNone(this string! candidate) -> Funcky.Monads.Option<System.TimeSpan>
 static Funcky.Extensions.ParseExtensions.ParseTimeSpanOrNone(this string! candidate, System.IFormatProvider! provider) -> Funcky.Monads.Option<System.TimeSpan>
 static Funcky.Functional.False<T0, T1>(T0 ω0, T1 ω1) -> bool
+static Funcky.Functional.Retry<TResult>(System.Func<Funcky.Monads.Option<TResult>>! producer, Funcky.RetryPolicies.IRetryPolicy! retryPolicy) -> Funcky.Monads.Option<TResult>
+static Funcky.Functional.RetryAsync<TResult>(System.Func<System.Threading.Tasks.Task<Funcky.Monads.Option<TResult>>!>! producer, Funcky.RetryPolicies.IRetryPolicy! retryPolicy) -> System.Threading.Tasks.Task<Funcky.Monads.Option<TResult>>!
 static Funcky.Functional.True<T0, T1>(T0 ω0, T1 ω1) -> bool
 static Funcky.Monads.Option<TItem>.implicit operator Funcky.Monads.Option<TItem>(TItem item) -> Funcky.Monads.Option<TItem>
 static Funcky.Sequence.Cycle<TItem>(TItem element) -> System.Collections.Generic.IEnumerable<TItem>!

--- a/Funcky/RetryPolicies/ConstantDelayPolicy.cs
+++ b/Funcky/RetryPolicies/ConstantDelayPolicy.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Funcky
+namespace Funcky.RetryPolicies
 {
     public class ConstantDelayPolicy : IRetryPolicy
     {

--- a/Funcky/RetryPolicies/DoNotRetryPolicy.cs
+++ b/Funcky/RetryPolicies/DoNotRetryPolicy.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Funcky
+namespace Funcky.RetryPolicies
 {
     public sealed class DoNotRetryPolicy : IRetryPolicy
     {

--- a/Funcky/RetryPolicies/ExponentialBackOffRetryPolicy.cs
+++ b/Funcky/RetryPolicies/ExponentialBackOffRetryPolicy.cs
@@ -1,13 +1,13 @@
 using System;
 
-namespace Funcky
+namespace Funcky.RetryPolicies
 {
-    public sealed class ExponentialBackoffRetryPolicy : IRetryPolicy
+    public sealed class ExponentialBackOffRetryPolicy : IRetryPolicy
     {
         private const double BaseFactor = 1.5;
         private readonly TimeSpan _firstDelay;
 
-        public ExponentialBackoffRetryPolicy(int maxRetry, TimeSpan firstDelay)
+        public ExponentialBackOffRetryPolicy(int maxRetry, TimeSpan firstDelay)
         {
             MaxRetries = maxRetry;
             _firstDelay = firstDelay;

--- a/Funcky/RetryPolicies/IRetryPolicy.cs
+++ b/Funcky/RetryPolicies/IRetryPolicy.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Funcky
+namespace Funcky.RetryPolicies
 {
     public interface IRetryPolicy
     {

--- a/Funcky/RetryPolicies/LinearBackoffRetryPolicy.cs
+++ b/Funcky/RetryPolicies/LinearBackoffRetryPolicy.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Funcky
+namespace Funcky.RetryPolicies
 {
     public sealed class LinearBackoffRetryPolicy : IRetryPolicy
     {

--- a/Funcky/RetryPolicies/NoDelayRetryPolicy.cs
+++ b/Funcky/RetryPolicies/NoDelayRetryPolicy.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Funcky
+namespace Funcky.RetryPolicies
 {
     public sealed class NoDelayRetryPolicy : ConstantDelayPolicy
     {


### PR DESCRIPTION
For funcky 3.0 we move the Retry Policies into their own namespace.