### PR TITLE
Partition materializes the source enumerable

### DIFF
--- a/Funcky.Test/Extensions/EnumerableExtensions/PartitionTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/PartitionTest.cs
@@ -8,14 +8,6 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
 {
     public sealed class PartitionTest
     {
-        [Fact(Skip = "TODO issue #271")]
-        public void PartitionIsEnumeratedLazily()
-        {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
-
-            _ = doNotEnumerate.Partition(True);
-        }
-
         [Fact]
         public void ReturnsTwoEmptyEnumerablesWhenSourceIsEmpty()
         {


### PR DESCRIPTION
* It is documented see remark in xml-doc
* I do not see a way around materialzation
=> we can remove the offending test