### PR TITLE
Reorder changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,101 +1,58 @@
 # Changelog
+All notable changes to this project will be documented in this file.
+Funcky adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.6.0
-* Add ToEnumerable function to `Option<T>`.
-* Add `WhereSelect` extension function for `IEnumerable<T>`.
-* Add missing overload for nullary actions to `ActionToUnit`.
+## Unreleased
+* Add the async equivalent of `Functional.NoOperation`: `Functional.NoOperationAsync`
 
-## 1.7.0
-* Add nullability annotations to everything except for `Monads.Reader`.
-* Add a function for creating an `Option<T>` from a nullable value: `Option.From`.
-* `Either.Match` now throws when called on an `Either` value created using `default(Either<L, R>)`.
-* Add `True` and `False` functions to public API
-* Match of `Result` Monad accepts actions
-* Add `FirstOrNone`, `LastOrNone` and `SingleOrNone` extension functions
+### Currying
+* Funcky provides currying also on `Action`s.
+* Added Property tests for Currying
 
-## 1.8.0
-* Added overload for `AndThen` which flattens the `Option`
-* Add `Where` method to `Option<T>`, which allows filtering the `Option` by a predicate.
-* Add overload for `Option<T>.SelectMany` that takes only a selector.
-* Add `WhereNotNull` extension method for `IEnumerable<T>`.
+## Funcky 2.4.0
+### `Try*` → `*OrNone`
+We've renamed all `Try*` methods, such as `TryParse`, `TryGet` value to `*OrNone`.
+The old methods are still available, but marked as obsolete and will be removed in 3.0.0.
 
-## 2.0.0-rc.1
-* Full nullable support introduced with C# 8
-* Rename `Option.From` -> `Option.FromNullable` and remove overload that takes non-nullable value types.
-* Use `Func<T, bool>` instead of `Predicate<T>` in predicate composition functions (`Functional.All`, `Functional.Any`, `Functional.Not`),
-  because most APIs in `System` use `Func`.
-* `Functional.Any` now returns `false` when the given list of predicates is empty.
-* The `Each` extension method on `IEnumerable<T>` has been renamed to `ForEach`.
-* Unify `Option<T>.ToEnumerable` and `Yield` to `ToEnumerable`
-* Remove `Reader` monad based on `await`.
-* `Exception` created by `Result` monad contains valid stack trace
+### Factory methods for `IEnumerable<T>`
+This release adds some new factory methods for creating `IEnumerable<T>`
+to the `Sequence` class:
+* `Sequence.RepeatRange`: Generates a sequence that contains the same sequence of elements the given number of times
+* `Sequence.Cycle`: Cycles the same element over and over again as an endless generator.
+* `Sequence.CycleRange`: Generates a sequence that contains the same sequence of elements over and over again as an endless generator
+* `Sequence.Concat`
 
-## 2.0.0-rc.2
-* Move the `Ok` constructor of `Result<T>` to a non-generic class. This allows for the compiler to infer the generic type.
-  Old: `Result<int>.Ok(10)`. New: `Result.Ok(10)`.
-* Add `IndexOfOrNone`, `LastIndexOfOrNone`, `IndexOfAnyOrNone` and `LastIndexOfAnyOrNone` extension methods to `string`.
-* Rename `OrElse` overloads that return the item to `GetOrElse` which improves overload resolution.
-* Added `Curry`, `Uncurry` and `Flip` to the `Functional` Class
-* Remove `IToString`.
-* Mark our functions as `[Pure]`.
-* Fix incorrect implementation on `Result.SelectMany` which called the `selectedResultSelector` even when the
-  result was an error. As a result (pun intended) of the fix, `ResultCombinationException` is no longer needed and also removed.
+### More Extension Methods
+#### for `IEnumerable<T>`
+  * `Materialize`: Materializes all the items of a lazy enumerable.
+  * `PowerSet`: Returns a sequence with the set of all subsets
+  * `Shuffle`: Returns the given sequence in random Order in O(n).
+  * `Split`: Splits the source sequence a separator.
+  * `ZipLongest`: Zips two sequences with different lengths.
+#### for `string`
+* `SplitLazy`: Splits a string by separator lazily.
+* `SplitLines`: Splits a string by newline lazily.
+#### for `Func`
+* `Curry`
+* `Uncurry`
+* `Flip`
+* `Compose`
 
-## 2.0.0
+### `EitherOrBoth`
+EitherOrBoth is a new data type that can represent `Left`, `Right` and `Both`. It is used in `ZipLongest`.
 
-### Breaking Changes
-* Remove `Reader` monad based on `await`.
-* Remove `IToString`.
-* Remove overload for `Option.From` that flattens passed `Option`s.
-* Move `ToEnumerable` extension method to its own class.
-  This is only a breaking change if you've used the extension method as normal method.
-  In that case you need to change `EnumerableExtensions.ToEnumerable` to `ObjectExtensions.ToEnumerable`.
-* Rename `Option.From` to `Option.FromNullable` and remove overload that takes non-nullable value types.
-* Unify `Option<T>.ToEnumerable` and `Yield` to `ToEnumerable`
-* Rename `OrElse` overloads that return the item to `GetOrElse` which improves overload resolution.
-* The `Each` extension method on `IEnumerable<T>` has been renamed to `ForEach`.
-* Move the `Ok` constructor of `Result<T>` to a non-generic class. This allows for the compiler to infer the generic type.
-  Old: `Result<int>.Ok(10)`. New: `Result.Ok(10)`.
-* Use `Func<T, bool>` instead of `Predicate<T>` in predicate composition functions (`Functional.All`, `Functional.Any`, `Functional.Not`),
-  because most APIs in `System` use `Func`.
-* `Functional.Any` now returns `false` when the given list of predicates is empty.
+### `Monad.Return`
+This release adds a `Return` method for all monad types in Funcky:
+* `Option.Return`
+* `Either<TLeft>.Return`
+* `Result.Return`
 
-### Fixes
-* Fix incorrect `Equals` implementation on `Option`.
-  `Equals` previously returned `true` when comparing a `None` value with a `Some` value containing the default value of the type.
-* `Exception` created by `Result` monad contains valid stack trace
-* Fix incorrect implementation on `Result.SelectMany` which called the `selectedResultSelector` even when the
-  result was an error. As a result (pun intended) of the fix, `ResultCombinationException` is no longer needed and also removed.
+### `OptionEqualityComparer`
+To support more advanced comparison scenarios, `OptionEqualityComparer` has been added similar to the already existing `OptionComparer`.
 
-### Additions
-* Add `IndexOfOrNone`, `LastIndexOfOrNone`, `IndexOfAnyOrNone` and `LastIndexOfAnyOrNone` extension methods to `string`.
-* Added `Curry`, `Uncurry` and `Flip` to the `Functional` Class
-* Add extension method for `HttpHeaders.TryGetValues`, which returns an `Option`.
-* Add extension methods for getting `Stream` properties that are not always available, as `Option`:
-  `GetLengthOrNone`, `GetPositionOrNone`, `GetReadTimeoutOrNone`, `GetWriteTimeoutOrNone`.
-* Add `None` extension method to `IEnumerable`.
-* `Option<Task<T>>`, `Option<Task>` and their `ValueTask` equivalents are now awaitable:
-  ```csharp
-  var answer = await Option.Some(Task.FromResult(42));
-  ```
-
-### Improvements
-* Full nullable support introduced with C# 8.
-* Mark our functions as `[Pure]`.
-* Implement `IEquatable` on `Option`, `Result` and `Either`.
-
-## Funcky 2.1.0 | Funcky.xUnit 0.1.1
-* Add `Inspect` method to `Option` akin to `IEnumerable.Inspect`.
-* Add `ToTheoryData` extension for `IEnumerable<T>` for xUnit.
-* Add `Unit.Value` as a way to a get a `Unit` value.
-* Add `Functional.Retry` which retries a producer until `Option.Some` is returned.
-
-## Funcky 2.1.1 | Funcky.xUnit 0.1.2
-* Re-release of previous release with correct assemblies.
-
-## Funcky 2.2.0 | Funcky.xUnit 0.1.3
-* Added overload to `Functional.Retry` with a `IRetryPolicy`.
-* Added `None` overload that takes no predicate.
+### Smaller Improvements
+* Added a missing `Match` overload to `Either` that takes `Action`s
+* Added additional overloads for `Functional.True` and `Functional.False` for up to four parameters.
 
 ## Funcky 2.3.0
 * `net5.0` has been added to Funcky's target frameworks.
@@ -174,56 +131,98 @@ that provide the missing functionality:
 * `ObjectExtensions.ToEnumerable` has been deprecated in favor of `Sequence.FromNullable`.
 * `RequireClass` and `RequireStruct` have been obsoleted with no replacement.
 
-## Funcky 2.4.0
-### `Try*` → `*OrNone`
-We've renamed all `Try*` methods, such as `TryParse`, `TryGet` value to `*OrNone`.
-The old methods are still available, but marked as obsolete and will be removed in 3.0.0.
+## Funcky 2.2.0 | Funcky.xUnit 0.1.3
+* Added overload to `Functional.Retry` with a `IRetryPolicy`.
+* Added `None` overload that takes no predicate.
 
-### Factory methods for `IEnumerable<T>`
-This release adds some new factory methods for creating `IEnumerable<T>`
-to the `Sequence` class:
-* `Sequence.RepeatRange`: Generates a sequence that contains the same sequence of elements the given number of times
-* `Sequence.Cycle`: Cycles the same element over and over again as an endless generator.
-* `Sequence.CycleRange`: Generates a sequence that contains the same sequence of elements over and over again as an endless generator
-* `Sequence.Concat`
+## Funcky 2.1.1 | Funcky.xUnit 0.1.2
+* Re-release of previous release with correct assemblies.
 
-### More Extension Methods
-#### for `IEnumerable<T>`
-  * `Materialize`: Materializes all the items of a lazy enumerable.
-  * `PowerSet`: Returns a sequence with the set of all subsets
-  * `Shuffle`: Returns the given sequence in random Order in O(n).
-  * `Split`: Splits the source sequence a separator.
-  * `ZipLongest`: Zips two sequences with different lengths.
-#### for `string`
-* `SplitLazy`: Splits a string by separator lazily.
-* `SplitLines`: Splits a string by newline lazily.
-#### for `Func`
-* `Curry`
-* `Uncurry`
-* `Flip`
-* `Compose`
+## Funcky 2.1.0 | Funcky.xUnit 0.1.1
+* Add `Inspect` method to `Option` akin to `IEnumerable.Inspect`.
+* Add `ToTheoryData` extension for `IEnumerable<T>` for xUnit.
+* Add `Unit.Value` as a way to a get a `Unit` value.
+* Add `Functional.Retry` which retries a producer until `Option.Some` is returned.
 
-### `EitherOrBoth`
-EitherOrBoth is a new data type that can represent `Left`, `Right` and `Both`. It is used in `ZipLongest`.
+## 2.0.0
+### Breaking Changes
+* Remove `Reader` monad based on `await`.
+* Remove `IToString`.
+* Remove overload for `Option.From` that flattens passed `Option`s.
+* Move `ToEnumerable` extension method to its own class.
+  This is only a breaking change if you've used the extension method as normal method.
+  In that case you need to change `EnumerableExtensions.ToEnumerable` to `ObjectExtensions.ToEnumerable`.
+* Rename `Option.From` to `Option.FromNullable` and remove overload that takes non-nullable value types.
+* Unify `Option<T>.ToEnumerable` and `Yield` to `ToEnumerable`
+* Rename `OrElse` overloads that return the item to `GetOrElse` which improves overload resolution.
+* The `Each` extension method on `IEnumerable<T>` has been renamed to `ForEach`.
+* Move the `Ok` constructor of `Result<T>` to a non-generic class. This allows for the compiler to infer the generic type.
+  Old: `Result<int>.Ok(10)`. New: `Result.Ok(10)`.
+* Use `Func<T, bool>` instead of `Predicate<T>` in predicate composition functions (`Functional.All`, `Functional.Any`, `Functional.Not`),
+  because most APIs in `System` use `Func`.
+* `Functional.Any` now returns `false` when the given list of predicates is empty.
 
-### `Monad.Return`
-This release adds a `Return` method for all monad types in Funcky:
-* `Option.Return`
-* `Either<TLeft>.Return`
-* `Result.Return`
+### Fixes
+* Fix incorrect `Equals` implementation on `Option`.
+  `Equals` previously returned `true` when comparing a `None` value with a `Some` value containing the default value of the type.
+* `Exception` created by `Result` monad contains valid stack trace
+* Fix incorrect implementation on `Result.SelectMany` which called the `selectedResultSelector` even when the
+  result was an error. As a result (pun intended) of the fix, `ResultCombinationException` is no longer needed and also removed.
 
-### `OptionEqualityComparer`
-To support more advanced comparison scenarios, `OptionEqualityComparer` has been added similar to the already existing `OptionComparer`.
+### Additions
+* Add `IndexOfOrNone`, `LastIndexOfOrNone`, `IndexOfAnyOrNone` and `LastIndexOfAnyOrNone` extension methods to `string`.
+* Added `Curry`, `Uncurry` and `Flip` to the `Functional` Class
+* Add extension method for `HttpHeaders.TryGetValues`, which returns an `Option`.
+* Add extension methods for getting `Stream` properties that are not always available, as `Option`:
+  `GetLengthOrNone`, `GetPositionOrNone`, `GetReadTimeoutOrNone`, `GetWriteTimeoutOrNone`.
+* Add `None` extension method to `IEnumerable`.
+* `Option<Task<T>>`, `Option<Task>` and their `ValueTask` equivalents are now awaitable:
+  ```csharp
+  var answer = await Option.Some(Task.FromResult(42));
+  ```
 
-### Smaller Improvements
-* Added a missing `Match` overload to `Either` that takes `Action`s
-* Added additional overloads for `Functional.True` and `Functional.False` for up to four parameters.
+### Improvements
+* Full nullable support introduced with C# 8.
+* Mark our functions as `[Pure]`.
+* Implement `IEquatable` on `Option`, `Result` and `Either`.
 
-## Unreleased
+## 2.0.0-rc.2
+* Move the `Ok` constructor of `Result<T>` to a non-generic class. This allows for the compiler to infer the generic type.
+  Old: `Result<int>.Ok(10)`. New: `Result.Ok(10)`.
+* Add `IndexOfOrNone`, `LastIndexOfOrNone`, `IndexOfAnyOrNone` and `LastIndexOfAnyOrNone` extension methods to `string`.
+* Rename `OrElse` overloads that return the item to `GetOrElse` which improves overload resolution.
+* Added `Curry`, `Uncurry` and `Flip` to the `Functional` Class
+* Remove `IToString`.
+* Mark our functions as `[Pure]`.
+* Fix incorrect implementation on `Result.SelectMany` which called the `selectedResultSelector` even when the
+  result was an error. As a result (pun intended) of the fix, `ResultCombinationException` is no longer needed and also removed.
 
-* Add the async equivalent of `Functional.NoOperation`: `Functional.NoOperationAsync`
+## 2.0.0-rc.1
+* Full nullable support introduced with C# 8
+* Rename `Option.From` -> `Option.FromNullable` and remove overload that takes non-nullable value types.
+* Use `Func<T, bool>` instead of `Predicate<T>` in predicate composition functions (`Functional.All`, `Functional.Any`, `Functional.Not`),
+  because most APIs in `System` use `Func`.
+* `Functional.Any` now returns `false` when the given list of predicates is empty.
+* The `Each` extension method on `IEnumerable<T>` has been renamed to `ForEach`.
+* Unify `Option<T>.ToEnumerable` and `Yield` to `ToEnumerable`
+* Remove `Reader` monad based on `await`.
+* `Exception` created by `Result` monad contains valid stack trace
 
-### Currying
+## 1.8.0
+* Added overload for `AndThen` which flattens the `Option`
+* Add `Where` method to `Option<T>`, which allows filtering the `Option` by a predicate.
+* Add overload for `Option<T>.SelectMany` that takes only a selector.
+* Add `WhereNotNull` extension method for `IEnumerable<T>`.
 
-* Funcky provides currying also on `Action`s.
-* Added Property tests for Currying
+## 1.7.0
+* Add nullability annotations to everything except for `Monads.Reader`.
+* Add a function for creating an `Option<T>` from a nullable value: `Option.From`.
+* `Either.Match` now throws when called on an `Either` value created using `default(Either<L, R>)`.
+* Add `True` and `False` functions to public API
+* Match of `Result` Monad accepts actions
+* Add `FirstOrNone`, `LastOrNone` and `SingleOrNone` extension functions
+
+## 1.6.0
+* Add ToEnumerable function to `Option<T>`.
+* Add `WhereSelect` extension function for `IEnumerable<T>`.
+* Add missing overload for nullary actions to `ActionToUnit`.

--- a/changelog.md
+++ b/changelog.md
@@ -144,7 +144,7 @@ that provide the missing functionality:
 * Add `Unit.Value` as a way to a get a `Unit` value.
 * Add `Functional.Retry` which retries a producer until `Option.Some` is returned.
 
-## 2.0.0
+## Funcky 2.0.0
 ### Breaking Changes
 * Remove `Reader` monad based on `await`.
 * Remove `IToString`.
@@ -186,7 +186,7 @@ that provide the missing functionality:
 * Mark our functions as `[Pure]`.
 * Implement `IEquatable` on `Option`, `Result` and `Either`.
 
-## 2.0.0-rc.2
+## Funcky 2.0.0-rc.2
 * Move the `Ok` constructor of `Result<T>` to a non-generic class. This allows for the compiler to infer the generic type.
   Old: `Result<int>.Ok(10)`. New: `Result.Ok(10)`.
 * Add `IndexOfOrNone`, `LastIndexOfOrNone`, `IndexOfAnyOrNone` and `LastIndexOfAnyOrNone` extension methods to `string`.
@@ -197,7 +197,7 @@ that provide the missing functionality:
 * Fix incorrect implementation on `Result.SelectMany` which called the `selectedResultSelector` even when the
   result was an error. As a result (pun intended) of the fix, `ResultCombinationException` is no longer needed and also removed.
 
-## 2.0.0-rc.1
+## Funcky 2.0.0-rc.1
 * Full nullable support introduced with C# 8
 * Rename `Option.From` -> `Option.FromNullable` and remove overload that takes non-nullable value types.
 * Use `Func<T, bool>` instead of `Predicate<T>` in predicate composition functions (`Functional.All`, `Functional.Any`, `Functional.Not`),
@@ -208,13 +208,13 @@ that provide the missing functionality:
 * Remove `Reader` monad based on `await`.
 * `Exception` created by `Result` monad contains valid stack trace
 
-## 1.8.0
+## Funcky 1.8.0
 * Added overload for `AndThen` which flattens the `Option`
 * Add `Where` method to `Option<T>`, which allows filtering the `Option` by a predicate.
 * Add overload for `Option<T>.SelectMany` that takes only a selector.
 * Add `WhereNotNull` extension method for `IEnumerable<T>`.
 
-## 1.7.0
+## Funcky 1.7.0
 * Add nullability annotations to everything except for `Monads.Reader`.
 * Add a function for creating an `Option<T>` from a nullable value: `Option.From`.
 * `Either.Match` now throws when called on an `Either` value created using `default(Either<L, R>)`.
@@ -222,7 +222,7 @@ that provide the missing functionality:
 * Match of `Result` Monad accepts actions
 * Add `FirstOrNone`, `LastOrNone` and `SingleOrNone` extension functions
 
-## 1.6.0
+## Funcky 1.6.0
 * Add ToEnumerable function to `Option<T>`.
 * Add `WhereSelect` extension function for `IEnumerable<T>`.
 * Add missing overload for nullary actions to `ActionToUnit`.


### PR DESCRIPTION
Ordering the changelog from newest to oldest is more practical for reading
because the most relevant version (newest) comes first.

Also [Keep A Changelog](https://keepachangelog.com/en/1.0.0/) suggests this.
