### PR TITLE
Use properties instead of fields on `ValueWithPrevious`

### DIFF
--- a/Funcky/Extensions/EnumerableExtensions/ValueWithFirst.cs
+++ b/Funcky/Extensions/EnumerableExtensions/ValueWithFirst.cs
@@ -2,20 +2,12 @@ namespace Funcky.Extensions
 {
     public readonly struct ValueWithFirst<TValue>
     {
-        public ValueWithFirst(TValue value, bool isFirst)
-        {
-            Value = value;
-            IsFirst = isFirst;
-        }
+        public ValueWithFirst(TValue value, bool isFirst) => (Value, IsFirst) = (value, isFirst);
 
         public TValue Value { get; }
 
         public bool IsFirst { get; }
 
-        public void Deconstruct(out TValue value, out bool isFirst)
-        {
-            value = Value;
-            isFirst = IsFirst;
-        }
+        public void Deconstruct(out TValue value, out bool isFirst) => (value, isFirst) = (Value, IsFirst);
     }
 }

--- a/Funcky/Extensions/EnumerableExtensions/ValueWithIndex.cs
+++ b/Funcky/Extensions/EnumerableExtensions/ValueWithIndex.cs
@@ -2,20 +2,12 @@ namespace Funcky.Extensions
 {
     public readonly struct ValueWithIndex<TValue>
     {
-        public ValueWithIndex(TValue value, int index)
-        {
-            Value = value;
-            Index = index;
-        }
+        public ValueWithIndex(TValue value, int index) => (Value, Index) = (value, index);
 
         public TValue Value { get; }
 
         public int Index { get; }
 
-        public void Deconstruct(out TValue value, out int index)
-        {
-            value = Value;
-            index = Index;
-        }
+        public void Deconstruct(out TValue value, out int index) => (value, index) = (Value, Index);
     }
 }

--- a/Funcky/Extensions/EnumerableExtensions/ValueWithLast.cs
+++ b/Funcky/Extensions/EnumerableExtensions/ValueWithLast.cs
@@ -2,20 +2,12 @@ namespace Funcky.Extensions
 {
     public readonly struct ValueWithLast<TValue>
     {
-        public ValueWithLast(TValue value, bool isLast)
-        {
-            Value = value;
-            IsLast = isLast;
-        }
+        public ValueWithLast(TValue value, bool isLast) => (Value, IsLast) = (value, isLast);
 
         public TValue Value { get; }
 
         public bool IsLast { get; }
 
-        public void Deconstruct(out TValue value, out bool isLast)
-        {
-            value = Value;
-            isLast = IsLast;
-        }
+        public void Deconstruct(out TValue value, out bool isLast) => (value, isLast) = (Value, IsLast);
     }
 }

--- a/Funcky/Extensions/EnumerableExtensions/ValueWithPrevious.cs
+++ b/Funcky/Extensions/EnumerableExtensions/ValueWithPrevious.cs
@@ -5,11 +5,11 @@ namespace Funcky.Extensions
     public readonly struct ValueWithPrevious<TValue>
         where TValue : notnull
     {
-        public readonly TValue Value;
-
-        public readonly Option<TValue> Previous;
-
         public ValueWithPrevious(TValue value, Option<TValue> previous) => (Value, Previous) = (value, previous);
+
+        public TValue Value { get; }
+
+        public Option<TValue> Previous { get; }
 
         public void Deconstruct(out TValue value, out Option<TValue> previous) => (value, previous) = (Value, Previous);
     }

--- a/Funcky/PublicAPI.Unshipped.txt
+++ b/Funcky/PublicAPI.Unshipped.txt
@@ -10,8 +10,8 @@ static Funcky.Extensions.EnumerableExtensions.ForEach<T>(this System.Collections
 Funcky.Extensions.ValueWithPrevious<TValue>
 Funcky.Extensions.ValueWithPrevious<TValue>.Deconstruct(out TValue value, out Funcky.Monads.Option<TValue> previous) -> void
 Funcky.Extensions.ValueWithPrevious<TValue>.ValueWithPrevious(TValue value, Funcky.Monads.Option<TValue> previous) -> void
-readonly Funcky.Extensions.ValueWithPrevious<TValue>.Previous -> Funcky.Monads.Option<TValue>
-readonly Funcky.Extensions.ValueWithPrevious<TValue>.Value -> TValue
+Funcky.Extensions.ValueWithPrevious<TValue>.Previous.get -> Funcky.Monads.Option<TValue>
+Funcky.Extensions.ValueWithPrevious<TValue>.Value.get -> TValue
 static Funcky.Extensions.EnumerableExtensions.Intersperse<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, TSource element) -> System.Collections.Generic.IEnumerable<TSource>!
 static Funcky.Extensions.EnumerableExtensions.JoinToString<T>(this System.Collections.Generic.IEnumerable<T>! source, char separator) -> string!
 static Funcky.Extensions.EnumerableExtensions.JoinToString<T>(this System.Collections.Generic.IEnumerable<T>! source, string! separator) -> string!


### PR DESCRIPTION
Fixes #393