### PR TITLE
Unify and fix behaviour of `Result.Error`

### DIFF
--- a/Funcky.Test/Monads/ResultTest.cs
+++ b/Funcky.Test/Monads/ResultTest.cs
@@ -162,6 +162,16 @@ namespace Funcky.Test.Monads
         }
 
         [Fact]
+        public void ErrorConstructorLeavesExistingStackTraceUnchanged()
+        {
+            var result = InterestingStackTrace(1);
+            var expectedStackTraceString = FunctionalAssert.IsError(result).StackTrace;
+            _ = result.Match(ok: Result.Ok, error: Result<int>.Error);
+            var stackTraceString = FunctionalAssert.IsError(result).StackTrace;
+            Assert.Equal(expectedStackTraceString, stackTraceString);
+        }
+
+        [Fact]
         public void SelectManyWithOkResultMatchesTherightValue()
             => FunctionalAssert.IsOk(2, Result.Ok(1).SelectMany(i => Result.Ok(i + 1)));
 

--- a/Funcky/Monads/Result/Result.Core.cs
+++ b/Funcky/Monads/Result/Result.Core.cs
@@ -34,6 +34,9 @@ namespace Funcky.Monads
         public static bool operator !=(Result<TValidResult> lhs, Result<TValidResult> rhs)
             => !lhs.Equals(rhs);
 
+        /// <summary>Creates a new <see cref="Result{TValidResult}"/> from an <see cref="Exception"/> and sets
+        /// the stack trace if not already set.</summary>
+        /// <remarks>This method has side effects: It sets the stack trace on <paramref name="item"/> if not already set.</remarks>
         #if SET_CURRENT_STACK_TRACE_SUPPORTED
         // Methods with AggressiveInlining are always excluded from the stack trace.
         // This is required for <c>SetCurrentStackTrace</c> to work properly.

--- a/Funcky/Monads/Result/Result.Core.cs
+++ b/Funcky/Monads/Result/Result.Core.cs
@@ -46,11 +46,14 @@ namespace Funcky.Monads
         #endif
         public static Result<TValidResult> Error(Exception item)
         {
-            #if SET_CURRENT_STACK_TRACE_SUPPORTED
-            ExceptionDispatchInfo.SetCurrentStackTrace(item);
-            #else
-            item.SetStackTrace(new StackTrace(SkipLowestStackFrame, true));
-            #endif
+            if (item.StackTrace is null)
+            {
+                #if SET_CURRENT_STACK_TRACE_SUPPORTED
+                    ExceptionDispatchInfo.SetCurrentStackTrace(item);
+                #else
+                    item.SetStackTrace(new StackTrace(SkipLowestStackFrame, true));
+                #endif
+            }
 
             return new Result<TValidResult>(item);
         }

--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,10 @@
 All notable changes to this project will be documented in this file.
 Funcky adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
-
+## Unreleased
+* The behaviour of the `Result.Error` constructor has been changed regarding exceptions
+  with an already set stack trace. The original stack trace is now preserved.
+  Previously this resulted in the stacktrace being replaced (.NET < 5.0) or an error (.NET ≥ 5.0).
 * Added extensions `DequeueOrNone` and `PeekOrNone` on `Queue` and `ConcurrentQueue`
 
 ## Funcky 2.5.0


### PR DESCRIPTION
Resolves #388 