### PR TITLE
Add analyzer that suggests use of named arguments

### DIFF
--- a/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/AddArgumentNameCodeFix.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/AddArgumentNameCodeFix.cs
@@ -1,0 +1,55 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Funcky.Analyzers
+{
+    [Shared]
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AddArgumentNameCodeFix))]
+    public sealed class AddArgumentNameCodeFix : CodeFixProvider
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds
+            => ImmutableArray.Create(UseWithArgumentNamesAnalyzer.DiagnosticId);
+
+        public override FixAllProvider GetFixAllProvider()
+            => WellKnownFixAllProviders.BatchFixer;
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                var argumentSyntax = root.FindNode(diagnostic.Location.SourceSpan).FirstAncestorOrSelf<ArgumentSyntax>();
+                var operation = (IArgumentOperation)semanticModel.GetOperation(argumentSyntax);
+                context.RegisterCodeFix(CreateFix(context, argumentSyntax, operation.Parameter), diagnostic);
+            }
+        }
+
+        private CodeAction CreateFix(CodeFixContext context, ArgumentSyntax argument, IParameterSymbol parameter)
+            => CodeAction.Create(
+                string.Format(CodeFixResources.AddArgumentNameCodeFixTitle, parameter.Name),
+                AddArgumentLabelAsync(context.Document, argument, parameter),
+                nameof(AddArgumentNameCodeFix));
+
+        private static Func<CancellationToken, Task<Document>> AddArgumentLabelAsync(Document document, ArgumentSyntax argument, IParameterSymbol parameter)
+            => async cancellationToken =>
+            {
+                var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken);
+                return document.WithSyntaxRoot(syntaxRoot.ReplaceNode(argument, AddArgumentName(argument, parameter)));
+            };
+
+        private static ArgumentSyntax AddArgumentName(ArgumentSyntax argument, IParameterSymbol parameter)
+            => argument
+                .WithNameColon(NameColon(parameter.Name)
+                    .WithLeadingTrivia(argument.Expression.GetLeadingTrivia())
+                    .WithTrailingTrivia(Space))
+                .WithExpression(argument.Expression.WithoutLeadingTrivia());
+    }
+}

--- a/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/CodeFixResources.Designer.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/CodeFixResources.Designer.cs
@@ -61,6 +61,15 @@ namespace Funcky.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add argument name &apos;{0}&apos;.
+        /// </summary>
+        internal static string AddArgumentNameCodeFixTitle {
+            get {
+                return ResourceManager.GetString("AddArgumentNameCodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use Enumerable.Empty&lt;T&gt;.
         /// </summary>
         internal static string EnumerableRepeatNeverCodeFixTitle {

--- a/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/CodeFixResources.resx
+++ b/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/CodeFixResources.resx
@@ -117,6 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AddArgumentNameCodeFixTitle" xml:space="preserve">
+    <value>Add argument name '{0}'</value>
+    <comment>The title of the code fix.</comment>
+  </data>
   <data name="EnumerableRepeatNeverCodeFixTitle" xml:space="preserve">
     <value>Use Enumerable.Empty&lt;T&gt;</value>
     <comment>The title of the code fix.</comment>

--- a/Funcky.Analyzers/Funcky.Analyzers.Test/TestCode/UseWithArgumentNames.expected
+++ b/Funcky.Analyzers/Funcky.Analyzers.Test/TestCode/UseWithArgumentNames.expected
@@ -1,0 +1,29 @@
+using System;
+using System.Linq;
+using Funcky.CodeAnalysis;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {
+        private void Syntax()
+        {
+            Method(x: 10, y: 20);
+            Method(x: 10, y: 20);
+            Method(
+                x: 10, y: 20);
+            Method(
+                x: 10,
+                y: 20);
+        }
+
+        [UseWithArgumentNames]
+        private void Method(int x, int y) { }
+    }
+}
+
+namespace Funcky.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    internal sealed class UseWithArgumentNamesAttribute : Attribute { }
+}

--- a/Funcky.Analyzers/Funcky.Analyzers.Test/TestCode/UseWithArgumentNames.expected
+++ b/Funcky.Analyzers/Funcky.Analyzers.Test/TestCode/UseWithArgumentNames.expected
@@ -15,10 +15,14 @@ namespace ConsoleApplication1
             Method(
                 x: 10,
                 y: 20);
+            MethodWithKeywordAsArgument(@int: 10);
         }
 
         [UseWithArgumentNames]
         private void Method(int x, int y) { }
+
+        [UseWithArgumentNames]
+        private void MethodWithKeywordAsArgument(int @int) { }
     }
 }
 

--- a/Funcky.Analyzers/Funcky.Analyzers.Test/TestCode/UseWithArgumentNames.input
+++ b/Funcky.Analyzers/Funcky.Analyzers.Test/TestCode/UseWithArgumentNames.input
@@ -15,10 +15,14 @@ namespace ConsoleApplication1
             Method(
                 10,
                 20);
+            MethodWithKeywordAsArgument(10);
         }
 
         [UseWithArgumentNames]
         private void Method(int x, int y) { }
+
+        [UseWithArgumentNames]
+        private void MethodWithKeywordAsArgument(int @int) { }
     }
 }
 

--- a/Funcky.Analyzers/Funcky.Analyzers.Test/TestCode/UseWithArgumentNames.input
+++ b/Funcky.Analyzers/Funcky.Analyzers.Test/TestCode/UseWithArgumentNames.input
@@ -1,0 +1,29 @@
+using System;
+using System.Linq;
+using Funcky.CodeAnalysis;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {
+        private void Syntax()
+        {
+            Method(x: 10, 20);
+            Method(10, 20);
+            Method(
+                10, 20);
+            Method(
+                10,
+                20);
+        }
+
+        [UseWithArgumentNames]
+        private void Method(int x, int y) { }
+    }
+}
+
+namespace Funcky.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    internal sealed class UseWithArgumentNamesAttribute : Attribute { }
+}

--- a/Funcky.Analyzers/Funcky.Analyzers.Test/TestCode/ValidUseWithArgumentNames.input
+++ b/Funcky.Analyzers/Funcky.Analyzers.Test/TestCode/ValidUseWithArgumentNames.input
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using Funcky.CodeAnalysis;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {
+        private void Syntax()
+        {
+            Method(x: 10, y: 20);
+        }
+
+        [UseWithArgumentNames]
+        private void Method(int x, int y) { }
+    }
+}
+
+namespace Funcky.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    internal sealed class UseWithArgumentNamesAttribute : Attribute { }
+}

--- a/Funcky.Analyzers/Funcky.Analyzers.Test/TestCode/ValidUseWithArgumentNamesNoAttribute.input
+++ b/Funcky.Analyzers/Funcky.Analyzers.Test/TestCode/ValidUseWithArgumentNamesNoAttribute.input
@@ -1,0 +1,22 @@
+using System;
+using System.Linq;
+using Funcky.CodeAnalysis;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {
+        private void Syntax()
+        {
+            Method(10, 20);
+        }
+
+        private void Method(int x, int y) { }
+    }
+}
+
+namespace Funcky.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    internal sealed class UseWithArgumentNamesAttribute : Attribute { }
+}

--- a/Funcky.Analyzers/Funcky.Analyzers.Test/UseWithArgumentNamesTest.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers.Test/UseWithArgumentNamesTest.cs
@@ -1,0 +1,25 @@
+using Xunit;
+using VerifyCS = Funcky.Analyzers.Test.CSharpCodeFixVerifier<Funcky.Analyzers.UseWithArgumentNamesAnalyzer, Funcky.Analyzers.AddArgumentNameCodeFix>;
+
+namespace Funcky.Analyzers.Test
+{
+    public sealed class UseWithArgumentNamesTest
+    {
+        [Fact]
+        public async Task UsagesOfMethodsAnnotatedWithShouldUseNamedArgumentsAttributeGetWarning()
+        {
+            var expectedDiagnostics = new[]
+            {
+                VerifyCS.Diagnostic().WithSpan(11, 27, 11, 29).WithArguments("y"),
+                VerifyCS.Diagnostic().WithSpan(12, 20, 12, 22).WithArguments("x"),
+                VerifyCS.Diagnostic().WithSpan(12, 24, 12, 26).WithArguments("y"),
+                VerifyCS.Diagnostic().WithSpan(14, 17, 14, 19).WithArguments("x"),
+                VerifyCS.Diagnostic().WithSpan(14, 21, 14, 23).WithArguments("y"),
+                VerifyCS.Diagnostic().WithSpan(16, 17, 16, 19).WithArguments("x"),
+                VerifyCS.Diagnostic().WithSpan(17, 17, 17, 19).WithArguments("y"),
+            };
+
+            await VerifyWithSourceExample.VerifyDiagnosticAndCodeFix<UseWithArgumentNamesAnalyzer, AddArgumentNameCodeFix>(expectedDiagnostics, "UseWithArgumentNames");
+        }
+    }
+}

--- a/Funcky.Analyzers/Funcky.Analyzers.Test/UseWithArgumentNamesTest.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers.Test/UseWithArgumentNamesTest.cs
@@ -31,6 +31,7 @@ namespace Funcky.Analyzers.Test
                 VerifyCS.Diagnostic().WithSpan(14, 21, 14, 23).WithArguments("y"),
                 VerifyCS.Diagnostic().WithSpan(16, 17, 16, 19).WithArguments("x"),
                 VerifyCS.Diagnostic().WithSpan(17, 17, 17, 19).WithArguments("y"),
+                VerifyCS.Diagnostic().WithSpan(18, 41, 18, 43).WithArguments("int"),
             };
 
             await VerifyWithSourceExample.VerifyDiagnosticAndCodeFix<UseWithArgumentNamesAnalyzer, AddArgumentNameCodeFix>(expectedDiagnostics, "UseWithArgumentNames");

--- a/Funcky.Analyzers/Funcky.Analyzers.Test/UseWithArgumentNamesTest.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers.Test/UseWithArgumentNamesTest.cs
@@ -6,14 +6,14 @@ namespace Funcky.Analyzers.Test
     public sealed class UseWithArgumentNamesTest
     {
         [Fact]
-        public async Task ParametersThatAlreadyUseArgumentNamesGetNoDiagnostic()
+        public async Task ArgumentsThatAlreadyUseArgumentNamesGetNoDiagnostic()
         {
             var inputCode = await File.ReadAllTextAsync("TestCode/ValidUseWithArgumentNames.input");
             await VerifyCS.VerifyAnalyzerAsync(inputCode);
         }
 
         [Fact]
-        public async Task UsagesOfMethodsAnnotatedWithShouldUseNamedArgumentsAttributeGetWarning()
+        public async Task UsagesOfMethodsAnnotatedWithShouldUseNamedArgumentsAttributeGetWarningAndAreFixed()
         {
             var expectedDiagnostics = new[]
             {

--- a/Funcky.Analyzers/Funcky.Analyzers.Test/UseWithArgumentNamesTest.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers.Test/UseWithArgumentNamesTest.cs
@@ -6,6 +6,13 @@ namespace Funcky.Analyzers.Test
     public sealed class UseWithArgumentNamesTest
     {
         [Fact]
+        public async Task ParametersThatAlreadyUseArgumentNamesGetNoDiagnostic()
+        {
+            var inputCode = await File.ReadAllTextAsync("TestCode/ValidUseWithArgumentNames.input");
+            await VerifyCS.VerifyAnalyzerAsync(inputCode);
+        }
+
+        [Fact]
         public async Task UsagesOfMethodsAnnotatedWithShouldUseNamedArgumentsAttributeGetWarning()
         {
             var expectedDiagnostics = new[]

--- a/Funcky.Analyzers/Funcky.Analyzers.Test/UseWithArgumentNamesTest.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers.Test/UseWithArgumentNamesTest.cs
@@ -13,6 +13,13 @@ namespace Funcky.Analyzers.Test
         }
 
         [Fact]
+        public async Task ArgumentsForCallsToMethodsWithoutAttributeGetNoDiagnostic()
+        {
+            var inputCode = await File.ReadAllTextAsync("TestCode/ValidUseWithArgumentNamesNoAttribute.input");
+            await VerifyCS.VerifyAnalyzerAsync(inputCode);
+        }
+
+        [Fact]
         public async Task UsagesOfMethodsAnnotatedWithShouldUseNamedArgumentsAttributeGetWarningAndAreFixed()
         {
             var expectedDiagnostics = new[]

--- a/Funcky.Analyzers/Funcky.Analyzers.Test/VerifyWithSourceExample.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers.Test/VerifyWithSourceExample.cs
@@ -18,5 +18,18 @@ namespace Funcky.Analyzers.Test
 
             await CSharpCodeFixVerifier<TAnalyzer, TCodeFix>.VerifyCodeFixAsync(inputCode, expectedDiagnostic, expectedCode);
         }
+
+        public static async Task VerifyDiagnosticAndCodeFix<TAnalyzer, TCodeFix>(DiagnosticResult[] expectedDiagnostics, string testCode)
+            where TAnalyzer : DiagnosticAnalyzer, new()
+            where TCodeFix : CodeFixProvider, new()
+        {
+            var inputCode = File.ReadAllText($"TestCode/{testCode}.input");
+
+            await CSharpCodeFixVerifier<TAnalyzer, TCodeFix>.VerifyAnalyzerAsync(inputCode, expectedDiagnostics);
+
+            var expectedCode = File.ReadAllText($"TestCode/{testCode}.expected");
+
+            await CSharpCodeFixVerifier<TAnalyzer, TCodeFix>.VerifyCodeFixAsync(inputCode, expectedDiagnostics, expectedCode);
+        }
     }
 }

--- a/Funcky.Analyzers/Funcky.Analyzers/Resources.Designer.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers/Resources.Designer.cs
@@ -117,27 +117,27 @@ namespace Funcky.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use this method with argument names.
         /// </summary>
-        internal static string UseArgumentNamesAnalyzerDescription {
+        internal static string UseWithArgumentNamesAnalyzerAnalyzerTitle {
             get {
-                return ResourceManager.GetString("UseArgumentNamesAnalyzerDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Add argument name for argument &apos;{0}&apos;.
-        /// </summary>
-        internal static string UseArgumentNamesAnalyzerMessageFormat {
-            get {
-                return ResourceManager.GetString("UseArgumentNamesAnalyzerMessageFormat", resourceCulture);
+                return ResourceManager.GetString("UseWithArgumentNamesAnalyzerAnalyzerTitle", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Use this method with argument names.
         /// </summary>
-        internal static string UseArgumentNamesAnalyzerTitle {
+        internal static string UseWithArgumentNamesAnalyzerDescription {
             get {
-                return ResourceManager.GetString("UseArgumentNamesAnalyzerTitle", resourceCulture);
+                return ResourceManager.GetString("UseWithArgumentNamesAnalyzerDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add argument name for argument &apos;{0}&apos;.
+        /// </summary>
+        internal static string UseWithArgumentNamesAnalyzerMessageFormat {
+            get {
+                return ResourceManager.GetString("UseWithArgumentNamesAnalyzerMessageFormat", resourceCulture);
             }
         }
     }

--- a/Funcky.Analyzers/Funcky.Analyzers/Resources.Designer.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers/Resources.Designer.cs
@@ -113,5 +113,32 @@ namespace Funcky.Analyzers {
                 return ResourceManager.GetString("EnumerableRepeatOnceAnalyzerTitle", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use this method with argument names.
+        /// </summary>
+        internal static string UseArgumentNamesAnalyzerDescription {
+            get {
+                return ResourceManager.GetString("UseArgumentNamesAnalyzerDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add argument name for argument &apos;{0}&apos;.
+        /// </summary>
+        internal static string UseArgumentNamesAnalyzerMessageFormat {
+            get {
+                return ResourceManager.GetString("UseArgumentNamesAnalyzerMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use this method with argument names.
+        /// </summary>
+        internal static string UseArgumentNamesAnalyzerTitle {
+            get {
+                return ResourceManager.GetString("UseArgumentNamesAnalyzerTitle", resourceCulture);
+            }
+        }
     }
 }

--- a/Funcky.Analyzers/Funcky.Analyzers/Resources.resx
+++ b/Funcky.Analyzers/Funcky.Analyzers/Resources.resx
@@ -141,4 +141,13 @@
     <value>Use of Enumerable.Repeat with no element</value>
     <comment>An optional longer localizable description of the diagnostic.</comment>
   </data>
+  <data name="UseArgumentNamesAnalyzerDescription" xml:space="preserve">
+    <value>Use this method with argument names</value>
+  </data>
+  <data name="UseArgumentNamesAnalyzerMessageFormat" xml:space="preserve">
+    <value>Add argument name for argument '{0}'</value>
+  </data>
+  <data name="UseArgumentNamesAnalyzerTitle" xml:space="preserve">
+    <value>Use this method with argument names</value>
+  </data>
 </root>

--- a/Funcky.Analyzers/Funcky.Analyzers/Resources.resx
+++ b/Funcky.Analyzers/Funcky.Analyzers/Resources.resx
@@ -141,13 +141,13 @@
     <value>Use of Enumerable.Repeat with no element</value>
     <comment>An optional longer localizable description of the diagnostic.</comment>
   </data>
-  <data name="UseArgumentNamesAnalyzerDescription" xml:space="preserve">
+  <data name="UseWithArgumentNamesAnalyzerDescription" xml:space="preserve">
     <value>Use this method with argument names</value>
   </data>
-  <data name="UseArgumentNamesAnalyzerMessageFormat" xml:space="preserve">
+  <data name="UseWithArgumentNamesAnalyzerMessageFormat" xml:space="preserve">
     <value>Add argument name for argument '{0}'</value>
   </data>
-  <data name="UseArgumentNamesAnalyzerTitle" xml:space="preserve">
+  <data name="UseWithArgumentNamesAnalyzerAnalyzerTitle" xml:space="preserve">
     <value>Use this method with argument names</value>
   </data>
 </root>

--- a/Funcky.Analyzers/Funcky.Analyzers/UseWithArgumentNamesAnalyzer.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers/UseWithArgumentNamesAnalyzer.cs
@@ -1,0 +1,55 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Funcky.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class UseWithArgumentNamesAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "λ0003";
+
+        private const string AttributeFullName = "Funcky.CodeAnalysis.UseWithArgumentNamesAttribute";
+
+        private const string Category = nameof(Funcky);
+        private static readonly DiagnosticDescriptor Descriptor = new(
+            id: DiagnosticId,
+            title: Resources.UseArgumentNamesAnalyzerTitle,
+            messageFormat: Resources.UseArgumentNamesAnalyzerMessageFormat,
+            description: Resources.UseArgumentNamesAnalyzerDescription,
+            category: Category,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+        }
+
+        private void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+        {
+            var node = (InvocationExpressionSyntax)context.Node;
+
+            if (context.SemanticModel.GetOperation(node) is IInvocationOperation invocation &&
+                context.Compilation.GetTypeByMetadataName(AttributeFullName) is { } attributeSymbol &&
+                invocation.TargetMethod.GetAttributes().Any(attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, attributeSymbol)))
+            {
+                foreach (var argument in node.ArgumentList.Arguments)
+                {
+                    if (argument.NameColon is null &&
+                        context.SemanticModel.GetOperation(argument) is IArgumentOperation argumentOperation)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(Descriptor, argument.GetLocation(), argumentOperation.Parameter.Name));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Funcky.Analyzers/Funcky.Analyzers/UseWithArgumentNamesAnalyzer.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers/UseWithArgumentNamesAnalyzer.cs
@@ -17,9 +17,9 @@ namespace Funcky.Analyzers
         private const string Category = nameof(Funcky);
         private static readonly DiagnosticDescriptor Descriptor = new(
             id: DiagnosticId,
-            title: Resources.UseArgumentNamesAnalyzerTitle,
-            messageFormat: Resources.UseArgumentNamesAnalyzerMessageFormat,
-            description: Resources.UseArgumentNamesAnalyzerDescription,
+            title: Resources.UseWithArgumentNamesAnalyzerAnalyzerTitle,
+            messageFormat: Resources.UseWithArgumentNamesAnalyzerMessageFormat,
+            description: Resources.UseWithArgumentNamesAnalyzerDescription,
             category: Category,
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);

--- a/Funcky.Analyzers/Funcky.Analyzers/UseWithArgumentNamesAnalyzer.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers/UseWithArgumentNamesAnalyzer.cs
@@ -10,11 +10,11 @@ namespace Funcky.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class UseWithArgumentNamesAnalyzer : DiagnosticAnalyzer
     {
-        public const string DiagnosticId = "λ0003";
+        public const string DiagnosticId = $"{DiagnosticName.Prefix}{DiagnosticName.Usage}03";
+        private const string Category = nameof(Funcky);
 
         private const string AttributeFullName = "Funcky.CodeAnalysis.UseWithArgumentNamesAttribute";
 
-        private const string Category = nameof(Funcky);
         private static readonly DiagnosticDescriptor Descriptor = new(
             id: DiagnosticId,
             title: Resources.UseWithArgumentNamesAnalyzerAnalyzerTitle,

--- a/Funcky.Test/Extensions/EnumerableExtensions/FirstSingleLastOrNoneTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/FirstSingleLastOrNoneTest.cs
@@ -6,19 +6,19 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [MemberData(nameof(ValueReferenceEnumerables))]
         public void GivenAnValueEnumerableFirstLastOrNoneGivesTheCorrectOption(List<int> valueEnumerable, List<string> referenceEnumerable)
         {
-            Assert.Equal(ExpectedOptionValue(valueEnumerable), valueEnumerable.FirstOrNone().Match(false, True));
-            Assert.Equal(ExpectedOptionValue(referenceEnumerable), referenceEnumerable.FirstOrNone().Match(false, True));
+            Assert.Equal(ExpectedOptionValue(valueEnumerable), valueEnumerable.FirstOrNone().Match(none: false, some: True));
+            Assert.Equal(ExpectedOptionValue(referenceEnumerable), referenceEnumerable.FirstOrNone().Match(none: false, some: True));
 
-            Assert.Equal(ExpectedOptionValue(valueEnumerable), valueEnumerable.LastOrNone().Match(false, True));
-            Assert.Equal(ExpectedOptionValue(referenceEnumerable), referenceEnumerable.LastOrNone().Match(false, True));
+            Assert.Equal(ExpectedOptionValue(valueEnumerable), valueEnumerable.LastOrNone().Match(none: false, some: True));
+            Assert.Equal(ExpectedOptionValue(referenceEnumerable), referenceEnumerable.LastOrNone().Match(none: false, some: True));
         }
 
         [Theory]
         [MemberData(nameof(ValueReferenceEnumerables))]
         public void GivenAnEnumerableSingleOrNoneGivesTheCorrectOption(List<int> valueEnumerable, List<string> referenceEnumerable)
         {
-            ExpectedSingleOrNoneBehaviour(valueEnumerable, () => valueEnumerable.SingleOrNone().Match(false, True));
-            ExpectedSingleOrNoneBehaviour(valueEnumerable, () => referenceEnumerable.SingleOrNone().Match(false, True));
+            ExpectedSingleOrNoneBehaviour(valueEnumerable, () => valueEnumerable.SingleOrNone().Match(none: false, some: True));
+            ExpectedSingleOrNoneBehaviour(valueEnumerable, () => referenceEnumerable.SingleOrNone().Match(none: false, some: True));
         }
 
         public static TheoryData<List<int>, List<string>> ValueReferenceEnumerables()

--- a/Funcky.Test/Extensions/EnumerableExtensions/ZipLongestTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/ZipLongestTest.cs
@@ -36,7 +36,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
             Assert.Equal(3, zipped.Count);
             foreach (var value in zipped)
             {
-                Assert.True(value.Match(False, False, True));
+                Assert.True(value.Match(left: False, right: False, both: True));
             }
         }
 

--- a/Funcky.Test/FunctionalClass/NoOperationTest.cs
+++ b/Funcky.Test/FunctionalClass/NoOperationTest.cs
@@ -8,7 +8,7 @@ namespace Funcky.Test.FunctionalClass
             var none = Option<int>.None();
 
             var sideEffect = 0;
-            none.Match(Functional.NoOperation, i => sideEffect = i);
+            none.Match(none: Functional.NoOperation, some: i => sideEffect = i);
 
             Assert.Equal(0, sideEffect);
         }

--- a/Funcky.Test/Monads/EitherTest.cs
+++ b/Funcky.Test/Monads/EitherTest.cs
@@ -34,7 +34,7 @@ namespace Funcky.Test.Monads
         {
             var value = default(Either<string, int>);
             Assert.Throws<NotSupportedException>(() =>
-                value.Match(Identity, i => i.ToString()));
+                value.Match(left: Identity, right: i => i.ToString()));
         }
 
         [Theory]

--- a/Funcky.Test/Monads/OptionTest.cs
+++ b/Funcky.Test/Monads/OptionTest.cs
@@ -102,7 +102,7 @@ namespace Funcky.Test.Monads
         {
             const string input = "123,some,x,1337,42,1,1000";
 
-            foreach (var number in input.Split(',').Select(ParseExtensions.ParseIntOrNone).Where(maybeInt => maybeInt.Match(false, True)))
+            foreach (var number in input.Split(',').Select(ParseExtensions.ParseIntOrNone).Where(maybeInt => maybeInt.Match(none: false, some: True)))
             {
                 _ = FunctionalAssert.IsSome(number);
             }
@@ -159,7 +159,7 @@ namespace Funcky.Test.Monads
         {
             var input = "123,some,x,1337,42,1,1000";
 
-            foreach (var number in input.Split(',').Select(ParseExtensions.ParseIntOrNone).Where(maybeInt => maybeInt.Match(false, True)))
+            foreach (var number in input.Split(',').Select(ParseExtensions.ParseIntOrNone).Where(maybeInt => maybeInt.Match(none: false, some: True)))
             {
                 var value = number.Match(
                     none: () => 0,
@@ -221,8 +221,8 @@ namespace Funcky.Test.Monads
             var none = Option<int>.None();
             var some = Option.Some(42);
 
-            Assert.False(none.AndThen(_ => Option.Some(1337)).Match(false, v => v == 1337));
-            Assert.True(some.AndThen(_ => Option.Some(1337)).Match(false, v => v == 1337));
+            Assert.False(none.AndThen(_ => Option.Some(1337)).Match(none: false, some: v => v == 1337));
+            Assert.True(some.AndThen(_ => Option.Some(1337)).Match(none: false, some: v => v == 1337));
         }
 
         [Fact]

--- a/Funcky/CodeAnalysis/UseWithArgumentNamesAttribute.cs
+++ b/Funcky/CodeAnalysis/UseWithArgumentNamesAttribute.cs
@@ -1,5 +1,6 @@
 namespace Funcky.CodeAnalysis
 {
+    /// <summary>Methods annotated with this attribute should be used with named arguments.</summary>
     [AttributeUsage(AttributeTargets.Method)]
     internal sealed class UseWithArgumentNamesAttribute : Attribute
     {

--- a/Funcky/CodeAnalysis/UseWithArgumentNamesAttribute.cs
+++ b/Funcky/CodeAnalysis/UseWithArgumentNamesAttribute.cs
@@ -1,0 +1,7 @@
+namespace Funcky.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    internal sealed class UseWithArgumentNamesAttribute : Attribute
+    {
+    }
+}

--- a/Funcky/DataTypes/EitherOrBoth.cs
+++ b/Funcky/DataTypes/EitherOrBoth.cs
@@ -1,3 +1,4 @@
+using Funcky.CodeAnalysis;
 using Funcky.Internal;
 
 namespace Funcky.DataTypes
@@ -62,6 +63,7 @@ namespace Funcky.DataTypes
         public static EitherOrBoth<TLeft, TRight> Right(TRight right) => new(right);
 
         [Pure]
+        [UseWithArgumentNames]
         public TMatchResult Match<TMatchResult>(Func<TLeft, TMatchResult> left, Func<TRight, TMatchResult> right, Func<TLeft, TRight, TMatchResult> both)
             => _side switch
             {
@@ -72,6 +74,7 @@ namespace Funcky.DataTypes
                 _ => throw new NotSupportedException(UnknownSide),
             };
 
+        [UseWithArgumentNames]
         public void Match(Action<TLeft> left, Action<TRight> right, Action<TLeft, TRight> both)
         {
             switch (_side)

--- a/Funcky/Extensions/EnumerableExtensions/MaxOrNone.cs
+++ b/Funcky/Extensions/EnumerableExtensions/MaxOrNone.cs
@@ -51,7 +51,7 @@ namespace Funcky.Extensions
 
         private static Option<TResult> AggregateMax<TResult>(Option<TResult> min, TResult current)
             where TResult : notnull
-            => min.Match(current, m => Max(m, current));
+            => min.Match(none: current, some: m => Max(m, current));
 
         private static TSource Max<TSource>(TSource left, TSource right)
             => Comparer<TSource>.Default.Compare(left, right) > 0 ? left : right;

--- a/Funcky/Extensions/EnumerableExtensions/MinOrNone.cs
+++ b/Funcky/Extensions/EnumerableExtensions/MinOrNone.cs
@@ -51,7 +51,7 @@ namespace Funcky.Extensions
 
         private static Option<TResult> AggregateMin<TResult>(Option<TResult> min, TResult current)
             where TResult : notnull
-            => min.Match(current, m => Min(m, current));
+            => min.Match(none: current, some: m => Min(m, current));
 
         // For floats this defines a total order where NaN comes before negative infinity
         private static TSource Min<TSource>(TSource left, TSource right)

--- a/Funcky/Funcky.csproj
+++ b/Funcky/Funcky.csproj
@@ -38,6 +38,9 @@
         <None Include="build/Funcky.targets" Pack="true" PackagePath="buildTransitive" />
         <None Include="..\README.md" Pack="true" PackagePath="\"/>
     </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="ILLink.LinkAttributes.xml" LogicalName="ILLink.LinkAttributes.xml" />
+    </ItemGroup>
     <Import Project="..\GlobalUsings.props" />
     <Import Project="..\FrameworkFeatureConstants.props" />
 </Project>

--- a/Funcky/ILLink.LinkAttributes.xml
+++ b/Funcky/ILLink.LinkAttributes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<linker>
+    <assembly fullname="Funcky">
+        <type fullname="Funcky.CodeAnalysis.UseWithArgumentNamesAttribute">
+            <attribute internal="RemoveAttributeInstances" />
+        </type>
+    </assembly>
+</linker>

--- a/Funcky/Monads/Either/Either.Core.cs
+++ b/Funcky/Monads/Either/Either.Core.cs
@@ -1,3 +1,5 @@
+using Funcky.CodeAnalysis;
+
 namespace Funcky.Monads
 {
     /// <remarks>
@@ -47,6 +49,7 @@ namespace Funcky.Monads
         public static Either<TLeft, TRight> Right(TRight right) => new(right);
 
         [Pure]
+        [UseWithArgumentNames]
         public TMatchResult Match<TMatchResult>(Func<TLeft, TMatchResult> left, Func<TRight, TMatchResult> right)
             => _side switch
             {
@@ -56,6 +59,7 @@ namespace Funcky.Monads
                 _ => throw new NotSupportedException(UnknownSide),
             };
 
+        [UseWithArgumentNames]
         public void Match(Action<TLeft> left, Action<TRight> right)
         {
             switch (_side)

--- a/Funcky/Monads/Either/Either.Core.cs
+++ b/Funcky/Monads/Either/Either.Core.cs
@@ -90,8 +90,8 @@ namespace Funcky.Monads
         [Pure]
         public override int GetHashCode()
             => Match(
-                left => left?.GetHashCode(),
-                right => right?.GetHashCode()) ?? 0;
+                left: left => left?.GetHashCode(),
+                right: right => right?.GetHashCode()) ?? 0;
 
         [Pure]
         public Either<TRight, TLeft> Flip()

--- a/Funcky/Monads/Option/Option.Core.cs
+++ b/Funcky/Monads/Option/Option.Core.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Funcky.CodeAnalysis;
 
 namespace Funcky.Monads
 {
@@ -24,8 +25,11 @@ namespace Funcky.Monads
         public static Option<TItem> None() => default;
 
         [Pure]
+        [UseWithArgumentNames]
         public TResult Match<TResult>(TResult none, Func<TItem, TResult> some)
-            => Match(() => none, some);
+            => Match(
+                none: () => none,
+                some: some);
 
         /// <summary>
         /// <para>Calls either <paramref name="none"/> when the option has no value or <paramref name="some"/> when the option
@@ -39,6 +43,7 @@ namespace Funcky.Monads
         /// </list></para>
         /// </summary>
         [Pure]
+        [UseWithArgumentNames]
         public TResult Match<TResult>(Func<TResult> none, Func<TItem, TResult> some)
             => _hasItem
                   ? some(_item)
@@ -54,6 +59,7 @@ namespace Funcky.Monads
         /// </list>
         /// </para>
         /// </summary>
+        [UseWithArgumentNames]
         public void Match(Action none, Action<TItem> some)
         {
             if (_hasItem)

--- a/Funcky/Monads/Option/Option.Monad.cs
+++ b/Funcky/Monads/Option/Option.Monad.cs
@@ -7,7 +7,7 @@ namespace Funcky.Monads
             where TResult : notnull
             => Match(
                  none: Option<TResult>.None,
-                 item => selector(item));
+                 some: item => selector(item));
 
         [Pure]
         public Option<TResult> SelectMany<TResult>(Func<TItem, Option<TResult>> selector)

--- a/Funcky/Monads/Result/Result.Core.cs
+++ b/Funcky/Monads/Result/Result.Core.cs
@@ -1,3 +1,4 @@
+using Funcky.CodeAnalysis;
 #if SET_CURRENT_STACK_TRACE_SUPPORTED
 using System.Runtime.ExceptionServices;
 #if STACK_TRACE_HIDDEN_SUPPORTED
@@ -62,11 +63,13 @@ namespace Funcky.Monads
         }
 
         [Pure]
+        [UseWithArgumentNames]
         public TMatchResult Match<TMatchResult>(Func<TValidResult, TMatchResult> ok, Func<Exception, TMatchResult> error)
             => _error is null
                 ? ok(_result)
                 : error(_error);
 
+        [UseWithArgumentNames]
         public void Match(Action<TValidResult> ok, Action<Exception> error)
         {
             if (_error is null)


### PR DESCRIPTION
## To do
* [x] Better tests
* [x] Code fix needs to auto-escape identifiers. See [`Emitter`](https://github.com/polyadic/funcky-discriminated-union/blob/974e89fab2d33a76ad9d9edaf67ba72d06340bad/Funcky.DiscriminatedUnion.SourceGeneration/Emitter.cs#L94-L98)
* [x] [Instruct linker to remove attribute](https://github.com/dotnet/linker/blob/main/docs/data-formats.md#custom-attributes-annotations-format)
  ```xml
  <?xml version="1.0" encoding="utf-8" ?>
  <linker>
      <assembly fullname="Funcky">
          <type fullname="Funcky.CodeAnalysis.UseWithArgumentNamesAttribute">
            <attribute internal="RemoveAttributeInstances" />
          </type>
      </assembly>
  </linker>
  ```
  ```xml
  <ItemGroup>
      <EmbeddedResource Include="ILLink.LinkAttributes.xml" LogicalName="ILLink.LinkAttributes.xml" />
  </ItemGroup>
  ```