### PR TITLE
Disable implicit namespace imports in the Test-Project

### DIFF
--- a/Funcky.Test/Funcky.Test.csproj
+++ b/Funcky.Test/Funcky.Test.csproj
@@ -5,6 +5,7 @@
         <LangVersion>preview</LangVersion>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
+        <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="FsCheck.Xunit" />


### PR DESCRIPTION
This avoids the "unused usings"-Warning in cases where the implicit namespace imports are activated implicitly.

https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/implicit-namespaces#change-category