### PR TITLE
Optimizations for `IList`

### DIFF
--- a/FrameworkFeatureConstants.props
+++ b/FrameworkFeatureConstants.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'">
-		<DefineConstants>$(DefineConstants);INDEX_OF_CHAR_COMPARISONTYPE_SUPPORTED;TIMESPAN_MULTIPLY_SUPPORTED;NULLABLE_ATTRIBUTES_SUPPORTED;SPLIT_ACCEPTS_STRING_SEPARATOR;LAZY_RETURN_CONSTRUCTOR;QUEUE_TRY_OVERLOADS</DefineConstants>
+		<DefineConstants>$(DefineConstants);INDEX_OF_CHAR_COMPARISONTYPE_SUPPORTED;TIMESPAN_MULTIPLY_SUPPORTED;NULLABLE_ATTRIBUTES_SUPPORTED;SPLIT_ACCEPTS_STRING_SEPARATOR;LAZY_RETURN_CONSTRUCTOR;QUEUE_TRY_OVERLOADS;OPTIMIZED_ELEMENT_AT</DefineConstants>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'">
 		<DefineConstants>$(DefineConstants);SET_CURRENT_STACK_TRACE_SUPPORTED</DefineConstants>

--- a/Funcky.Test/Extensions/EnumerableExtensions/AdjacentGroupByTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/AdjacentGroupByTest.cs
@@ -8,7 +8,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void AdjacentGroupByIsEnumeratedLazily()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
 
             _ = doNotEnumerate.AdjacentGroupBy(FailOnCall.Function<object, int>);
             _ = doNotEnumerate.AdjacentGroupBy(FailOnCall.Function<object, int>, EqualityComparer<int>.Default);

--- a/Funcky.Test/Extensions/EnumerableExtensions/CartesianProductTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/CartesianProductTest.cs
@@ -9,7 +9,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void CartesianProductIsEnumeratedLazily()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
 
             _ = doNotEnumerate.CartesianProduct(doNotEnumerate);
         }

--- a/Funcky.Test/Extensions/EnumerableExtensions/ChunkTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/ChunkTest.cs
@@ -8,7 +8,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void ChunkIsEnumeratedLazily()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
 
             _ = doNotEnumerate.Chunk(42);
         }

--- a/Funcky.Test/Extensions/EnumerableExtensions/FailOnEnumerationList.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/FailOnEnumerationList.cs
@@ -17,7 +17,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
 
         public int this[int index]
         {
-            get => index > 0 && index < _length ? index : throw new IndexOutOfRangeException();
+            get => index >= 0 && index < _length ? index : throw new IndexOutOfRangeException();
             set => throw new InvalidOperationException();
         }
 

--- a/Funcky.Test/Extensions/EnumerableExtensions/FailOnEnumerationList.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/FailOnEnumerationList.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+
+namespace Funcky.Test.Extensions.EnumerableExtensions
+{
+    internal sealed class FailOnEnumerationList : IList<int>
+    {
+        private readonly int _length;
+
+        public FailOnEnumerationList(int length)
+            => _length = length;
+
+        public int Count
+            => _length;
+
+        public bool IsReadOnly
+            => true;
+
+        public int this[int index]
+        {
+            get => index > 0 && index < _length ? index : throw new IndexOutOfRangeException();
+            set => throw new InvalidOperationException();
+        }
+
+        public void Add(int item)
+            => throw new InvalidOperationException();
+
+        public void Clear()
+            => throw new InvalidOperationException();
+
+        public bool Contains(int item)
+            => throw new InvalidOperationException();
+
+        public void CopyTo(int[] array, int arrayIndex)
+            => throw new InvalidOperationException();
+
+        public IEnumerator<int> GetEnumerator()
+            => throw new InvalidOperationException();
+
+        public int IndexOf(int item)
+            => throw new InvalidOperationException();
+
+        public void Insert(int index, int item)
+            => throw new InvalidOperationException();
+
+        public bool Remove(int item)
+            => throw new InvalidOperationException();
+
+        public void RemoveAt(int index)
+            => throw new InvalidOperationException();
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => throw new InvalidOperationException();
+    }
+}

--- a/Funcky.Test/Extensions/EnumerableExtensions/FailOnEnumerationList.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/FailOnEnumerationList.cs
@@ -18,37 +18,37 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         public int this[int index]
         {
             get => index >= 0 && index < _length ? index : throw new IndexOutOfRangeException();
-            set => throw new InvalidOperationException();
+            set => throw new NotSupportedException();
         }
 
         public void Add(int item)
-            => throw new InvalidOperationException();
+            => throw new NotSupportedException();
 
         public void Clear()
-            => throw new InvalidOperationException();
+            => throw new NotSupportedException();
 
         public bool Contains(int item)
-            => throw new InvalidOperationException();
+            => throw new NotSupportedException();
 
         public void CopyTo(int[] array, int arrayIndex)
-            => throw new InvalidOperationException();
+            => throw new NotSupportedException();
 
         public IEnumerator<int> GetEnumerator()
-            => throw new InvalidOperationException();
+            => throw new NotSupportedException();
 
         public int IndexOf(int item)
-            => throw new InvalidOperationException();
+            => throw new NotSupportedException();
 
         public void Insert(int index, int item)
-            => throw new InvalidOperationException();
+            => throw new NotSupportedException();
 
         public bool Remove(int item)
-            => throw new InvalidOperationException();
+            => throw new NotSupportedException();
 
         public void RemoveAt(int index)
-            => throw new InvalidOperationException();
+            => throw new NotSupportedException();
 
         IEnumerator IEnumerable.GetEnumerator()
-            => throw new InvalidOperationException();
+            => throw new NotSupportedException();
     }
 }

--- a/Funcky.Test/Extensions/EnumerableExtensions/ForEachTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/ForEachTest.cs
@@ -9,7 +9,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void ForEachIsEvaluatedEagerly()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
 
             Assert.Throws<XunitException>(() => doNotEnumerate.ForEach(Functional.NoOperation));
             Assert.Throws<XunitException>(() => doNotEnumerate.ForEach(UnitNoOperation));

--- a/Funcky.Test/Extensions/EnumerableExtensions/InspectTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/InspectTest.cs
@@ -8,7 +8,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void InspectIsEnumeratedLazily()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
 
             _ = doNotEnumerate.Inspect(NoOperation);
         }

--- a/Funcky.Test/Extensions/EnumerableExtensions/InterleaveTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/InterleaveTest.cs
@@ -8,7 +8,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void InterleaveIsEnumeratedLazily()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
 
             _ = doNotEnumerate.Interleave();
         }

--- a/Funcky.Test/Extensions/EnumerableExtensions/IntersperseTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/IntersperseTest.cs
@@ -8,7 +8,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void IntersperseIsEvaluatedLazily()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<int>();
+            var doNotEnumerate = new FailOnEnumerationSequence<int>();
             _ = doNotEnumerate.Intersperse(42);
         }
 

--- a/Funcky.Test/Extensions/EnumerableExtensions/MaterializeTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/MaterializeTest.cs
@@ -10,7 +10,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void MaterializeEnumeratesNonCollection()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
 
             Assert.Throws<XunitException>(() => doNotEnumerate.Materialize());
         }

--- a/Funcky.Test/Extensions/EnumerableExtensions/MergeTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/MergeTest.cs
@@ -9,7 +9,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void MergeIsEnumeratedLazily()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
 
             _ = doNotEnumerate.Merge(doNotEnumerate);
         }

--- a/Funcky.Test/Extensions/EnumerableExtensions/PairwiseTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/PairwiseTest.cs
@@ -8,7 +8,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void PairwiseIsEnumeratedLazily()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
 
             _ = doNotEnumerate.Pairwise();
         }

--- a/Funcky.Test/Extensions/EnumerableExtensions/PowerSetTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/PowerSetTest.cs
@@ -8,7 +8,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void APowerSetIsEnumeratedLazily()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
 
             _ = doNotEnumerate.PowerSet();
         }

--- a/Funcky.Test/Extensions/EnumerableExtensions/ShuffleTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/ShuffleTest.cs
@@ -10,7 +10,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void AShuffleIsEnumeratedLazily()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
 
             _ = doNotEnumerate.Shuffle();
         }

--- a/Funcky.Test/Extensions/EnumerableExtensions/SlidingWindowTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/SlidingWindowTest.cs
@@ -10,7 +10,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void ASlidingWindowIsEnumeratedLazily()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
 
             _ = doNotEnumerate.SlidingWindow(42);
         }

--- a/Funcky.Test/Extensions/EnumerableExtensions/SplitTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/SplitTest.cs
@@ -10,7 +10,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void SplitIsEnumeratedLazily()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
 
             _ = doNotEnumerate.Split(42);
         }

--- a/Funcky.Test/Extensions/EnumerableExtensions/TakeEveryTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/TakeEveryTest.cs
@@ -10,7 +10,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void TakeEveryIsEnumeratedLazily()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
 
             _ = doNotEnumerate.TakeEvery(42);
         }

--- a/Funcky.Test/Extensions/EnumerableExtensions/WhereNotNullTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/WhereNotNullTest.cs
@@ -8,7 +8,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void WhereNotNullIsEnumeratedLazily()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
 
             _ = doNotEnumerate.WhereNotNull();
         }

--- a/Funcky.Test/Extensions/EnumerableExtensions/WhereSelectTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/WhereSelectTest.cs
@@ -8,7 +8,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void WhereSelectNullIsEnumeratedLazily()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
 
             _ = doNotEnumerate.WhereSelect(_ => Option<object>.None());
         }

--- a/Funcky.Test/Extensions/EnumerableExtensions/WithFirstTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/WithFirstTest.cs
@@ -8,7 +8,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void WithFirstIsEnumeratedLazily()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
 
             _ = doNotEnumerate.WithFirst();
         }

--- a/Funcky.Test/Extensions/EnumerableExtensions/WithFirstTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/WithFirstTest.cs
@@ -49,5 +49,30 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
                 Assert.Equal(valueWithFirst.Value == 1, valueWithFirst.IsFirst);
             }
         }
+
+        [Fact]
+        public void ElementAtAccessIsOptimizedOnAnIListSourceWithIndex()
+        {
+            var length = 5000;
+            var nonEnumerableList = new FailOnEnumerationList(length);
+            var listWithLast = nonEnumerableList.WithFirst();
+
+            Assert.Equal(1337, listWithLast.ElementAt(1337).Value);
+
+            Assert.True(listWithLast.ElementAt(0).IsFirst);
+            Assert.False(listWithLast.ElementAt(1).IsFirst);
+            Assert.False(listWithLast.ElementAt(2500).IsFirst);
+            Assert.False(listWithLast.ElementAt(length - 2).IsFirst);
+            Assert.False(listWithLast.ElementAt(length - 1).IsFirst);
+        }
+
+        [Fact]
+        public void OptimizedSourceWithIndexCanBeEnumerated()
+        {
+            var length = 222;
+            var nonEnumerableList = Enumerable.Range(0, length).ToList();
+
+            Assert.Equal(length, nonEnumerableList.WithFirst().Aggregate(0, (sum, _) => sum + 1));
+        }
     }
 }

--- a/Funcky.Test/Extensions/EnumerableExtensions/WithIndexTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/WithIndexTest.cs
@@ -8,7 +8,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void WithIndexIsEnumeratedLazily()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
 
             _ = doNotEnumerate.WithIndex();
         }

--- a/Funcky.Test/Extensions/EnumerableExtensions/WithIndexTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/WithIndexTest.cs
@@ -52,9 +52,10 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         public void ElementAtAccessIsOptimizedOnAnIListSourceWithIndex()
         {
             var nonEnumerableList = new FailOnEnumerationList(5000);
-            var magicListWithIndex = nonEnumerableList.WithIndex();
+            var listWithIndex = nonEnumerableList.WithIndex();
 
-            Assert.Equal(1337, magicListWithIndex.ElementAt(1337).Index);
+            Assert.Equal(1337, listWithIndex.ElementAt(1337).Value);
+            Assert.Equal(listWithIndex.ElementAt(999).Value, listWithIndex.ElementAt(999).Index);
         }
 
         [Fact]

--- a/Funcky.Test/Extensions/EnumerableExtensions/WithIndexTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/WithIndexTest.cs
@@ -47,5 +47,23 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
                 Assert.Equal(valueWithIndex.Value, valueWithIndex.Index);
             }
         }
+
+        [Fact]
+        public void ElementAtAccessIsOptimizedOnAnIListSourceWithIndex()
+        {
+            var nonEnumerableList = new FailOnEnumerationList(5000);
+            var magicListWithIndex = nonEnumerableList.WithIndex();
+
+            Assert.Equal(1337, magicListWithIndex.ElementAt(1337).Index);
+        }
+
+        [Fact]
+        public void OptimizedSourceWithIndexCanBeEnumerated()
+        {
+            var length = 222;
+            var nonEnumerableList = Enumerable.Range(0, length).ToList();
+
+            Assert.Equal(length, nonEnumerableList.WithIndex().Aggregate(0, (sum, _) => sum + 1));
+        }
     }
 }

--- a/Funcky.Test/Extensions/EnumerableExtensions/WithLastTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/WithLastTest.cs
@@ -48,5 +48,30 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
                 Assert.Equal(valueWithLast.Value == length, valueWithLast.IsLast);
             }
         }
+
+        [Fact]
+        public void ElementAtAccessIsOptimizedOnAnIListSourceWithIndex()
+        {
+            var length = 5000;
+            var nonEnumerableList = new FailOnEnumerationList(length);
+            var listWithLast = nonEnumerableList.WithLast();
+
+            Assert.Equal(1337, listWithLast.ElementAt(1337).Value);
+
+            Assert.False(listWithLast.ElementAt(0).IsLast);
+            Assert.False(listWithLast.ElementAt(1).IsLast);
+            Assert.False(listWithLast.ElementAt(2500).IsLast);
+            Assert.False(listWithLast.ElementAt(length - 2).IsLast);
+            Assert.True(listWithLast.ElementAt(length - 1).IsLast);
+        }
+
+        [Fact]
+        public void OptimizedSourceWithIndexCanBeEnumerated()
+        {
+            var length = 222;
+            var nonEnumerableList = Enumerable.Range(0, length).ToList();
+
+            Assert.Equal(length, nonEnumerableList.WithLast().Aggregate(0, (sum, _) => sum + 1));
+        }
     }
 }

--- a/Funcky.Test/Extensions/EnumerableExtensions/WithLastTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/WithLastTest.cs
@@ -8,7 +8,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void WithLastIsEnumeratedLazily()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
 
             _ = doNotEnumerate.WithLast();
         }

--- a/Funcky.Test/Extensions/EnumerableExtensions/WithPreviousTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/WithPreviousTest.cs
@@ -46,5 +46,40 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
                 new ValueWithPrevious<string>("qux", "baz"));
             Assert.Equal(expectedSequenceWithPrevious, sequence.WithPrevious());
         }
+
+        [Fact]
+        public void ElementAtAccessIsOptimizedOnAnIListSourceWithIndex()
+        {
+            var length = 200;
+            var nonEnumerableList = new FailOnEnumerationList(length);
+            var listWithLast = nonEnumerableList.WithPrevious();
+
+            Assert.Equal(137, listWithLast.ElementAt(137).Value);
+
+            Assert.Equal(0, listWithLast.ElementAt(0).Value);
+            FunctionalAssert.IsNone(listWithLast.ElementAt(0).Previous);
+
+            foreach (var index in Enumerable.Range(1, length - 1))
+            {
+                CheckValues(listWithLast, index);
+            }
+        }
+
+        [Fact]
+        public void OptimizedSourceWithIndexCanBeEnumerated()
+        {
+            var length = 222;
+            var nonEnumerableList = Enumerable.Range(0, length).ToList();
+
+            Assert.Equal(length, nonEnumerableList.WithPrevious().Aggregate(0, (sum, _) => sum + 1));
+        }
+
+        private static void CheckValues(IEnumerable<ValueWithPrevious<int>> listWithLast, int index)
+        {
+            Assert.Equal(index, listWithLast.ElementAt(index).Value);
+
+            var previous = FunctionalAssert.IsSome(listWithLast.ElementAt(index).Previous);
+            Assert.Equal(index - 1, previous);
+        }
     }
 }

--- a/Funcky.Test/Extensions/EnumerableExtensions/WithPreviousTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/WithPreviousTest.cs
@@ -10,7 +10,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void WithPreviousIsEnumeratedLazily()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
 
             _ = doNotEnumerate.WithPrevious();
         }

--- a/Funcky.Test/Extensions/EnumerableExtensions/ZipLongestTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/ZipLongestTest.cs
@@ -8,7 +8,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions
         [Fact]
         public void ZipLongestIsEnumeratedLazily()
         {
-            var doNotEnumerate = new FailOnEnumerateSequence<object>();
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
 
             _ = doNotEnumerate.ZipLongest(doNotEnumerate, _ => Unit.Value);
         }

--- a/Funcky.Test/TestUtils/FailOnEnumerationSequence.cs
+++ b/Funcky.Test/TestUtils/FailOnEnumerationSequence.cs
@@ -1,13 +1,14 @@
+using System.Collections;
 using Xunit.Sdk;
 
 namespace Funcky.Test.TestUtils
 {
-    internal sealed class FailOnEnumerateSequence<T> : IEnumerable<T>
+    internal sealed class FailOnEnumerationSequence<T> : IEnumerable<T>
     {
         public IEnumerator<T> GetEnumerator()
             => throw new XunitException("Sequence was unexpectedly enumerated.");
 
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
     }
 }

--- a/Funcky/Extensions/EnumerableExtensions/ValueWithIndex.cs
+++ b/Funcky/Extensions/EnumerableExtensions/ValueWithIndex.cs
@@ -9,8 +9,5 @@ namespace Funcky.Extensions
         public int Index { get; }
 
         public void Deconstruct(out TValue value, out int index) => (value, index) = (Value, Index);
-
-        public static ValueWithIndex<TValue> Create(TValue value, int index)
-            => new(value, index);
     }
 }

--- a/Funcky/Extensions/EnumerableExtensions/ValueWithIndex.cs
+++ b/Funcky/Extensions/EnumerableExtensions/ValueWithIndex.cs
@@ -9,5 +9,8 @@ namespace Funcky.Extensions
         public int Index { get; }
 
         public void Deconstruct(out TValue value, out int index) => (value, index) = (Value, Index);
+
+        public static ValueWithIndex<TValue> Create(TValue value, int index)
+            => new(value, index);
     }
 }

--- a/Funcky/Extensions/EnumerableExtensions/WithFirst.cs
+++ b/Funcky/Extensions/EnumerableExtensions/WithFirst.cs
@@ -1,3 +1,5 @@
+using Funcky.Internal;
+
 namespace Funcky.Extensions
 {
     public static partial class EnumerableExtensions
@@ -10,6 +12,17 @@ namespace Funcky.Extensions
         /// <returns>Returns a sequence mapping each element into a type which has an IsFirst property which is true for the first element of the sequence.</returns>
         [Pure]
         public static IEnumerable<ValueWithFirst<TSource>> WithFirst<TSource>(this IEnumerable<TSource> source)
+            => source switch
+            {
+                IList<TSource> list => new ListWithSelector<TSource, ValueWithFirst<TSource>>(list, ValueWithFirst),
+                _ => source.WithFirstImplementation(),
+            };
+
+        private static Func<TSource, int, ValueWithFirst<TSource>> ValueWithFirst<TSource>(IList<TSource> list)
+            => (value, index)
+                => new(value, index == 0);
+
+        private static IEnumerable<ValueWithFirst<TSource>> WithFirstImplementation<TSource>(this IEnumerable<TSource> source)
         {
             using var enumerator = source.GetEnumerator();
 

--- a/Funcky/Extensions/EnumerableExtensions/WithFirst.cs
+++ b/Funcky/Extensions/EnumerableExtensions/WithFirst.cs
@@ -14,7 +14,7 @@ namespace Funcky.Extensions
         public static IEnumerable<ValueWithFirst<TSource>> WithFirst<TSource>(this IEnumerable<TSource> source)
             => source switch
             {
-                IList<TSource> list => new ListWithSelector<TSource, ValueWithFirst<TSource>>(list, ValueWithFirst),
+                IList<TSource> list => ListWithSelector.Create(list, ValueWithFirst),
                 _ => source.WithFirstImplementation(),
             };
 

--- a/Funcky/Extensions/EnumerableExtensions/WithIndex.cs
+++ b/Funcky/Extensions/EnumerableExtensions/WithIndex.cs
@@ -14,9 +14,12 @@ namespace Funcky.Extensions
         public static IEnumerable<ValueWithIndex<TSource>> WithIndex<TSource>(this IEnumerable<TSource> source)
             => source switch
             {
-                IList<TSource> list => ListWithSelector.Create(list, list => ValueWithIndex<TSource>),
+                IList<TSource> list => ListWithSelector.Create(list, ValueWithIndex),
                 _ => source.Select(ValueWithIndex<TSource>),
             };
+
+        private static Func<TSource, int, ValueWithIndex<TSource>> ValueWithIndex<TSource>(IList<TSource> dummy)
+            => ValueWithIndex<TSource>;
 
         private static ValueWithIndex<TValue> ValueWithIndex<TValue>(TValue value, int index)
             => new(value, index);

--- a/Funcky/Extensions/EnumerableExtensions/WithIndex.cs
+++ b/Funcky/Extensions/EnumerableExtensions/WithIndex.cs
@@ -14,7 +14,7 @@ namespace Funcky.Extensions
         public static IEnumerable<ValueWithIndex<TSource>> WithIndex<TSource>(this IEnumerable<TSource> source)
             => source switch
             {
-                IList<TSource> list => new ListWithSelector<TSource, ValueWithIndex<TSource>>(list, list => ValueWithIndex<TSource>),
+                IList<TSource> list => ListWithSelector.Create(list, list => ValueWithIndex<TSource>),
                 _ => source.Select(ValueWithIndex<TSource>),
             };
 

--- a/Funcky/Extensions/EnumerableExtensions/WithIndex.cs
+++ b/Funcky/Extensions/EnumerableExtensions/WithIndex.cs
@@ -14,8 +14,11 @@ namespace Funcky.Extensions
         public static IEnumerable<ValueWithIndex<TSource>> WithIndex<TSource>(this IEnumerable<TSource> source)
             => source switch
             {
-                IList<TSource> list => new ListWithIndex<TSource>(list),
-                _ => source.Select(ValueWithIndex<TSource>.Create),
+                IList<TSource> list => new ListWithSelector<TSource, ValueWithIndex<TSource>>(list, list => ValueWithIndex<TSource>),
+                _ => source.Select(ValueWithIndex<TSource>),
             };
+
+        private static ValueWithIndex<TValue> ValueWithIndex<TValue>(TValue value, int index)
+            => new(value, index);
     }
 }

--- a/Funcky/Extensions/EnumerableExtensions/WithIndex.cs
+++ b/Funcky/Extensions/EnumerableExtensions/WithIndex.cs
@@ -1,3 +1,5 @@
+using Funcky.Internal;
+
 namespace Funcky.Extensions
 {
     public static partial class EnumerableExtensions
@@ -10,6 +12,10 @@ namespace Funcky.Extensions
         /// <returns>Returns a sequence mapping each element together with an Index starting at 0.</returns>
         [Pure]
         public static IEnumerable<ValueWithIndex<TSource>> WithIndex<TSource>(this IEnumerable<TSource> source)
-            => source.Select((value, index) => new ValueWithIndex<TSource>(value, index));
+            => source switch
+            {
+                IList<TSource> list => new ListWithIndex<TSource>(list),
+                _ => source.Select(ValueWithIndex<TSource>.Create),
+            };
     }
 }

--- a/Funcky/Extensions/EnumerableExtensions/WithLast.cs
+++ b/Funcky/Extensions/EnumerableExtensions/WithLast.cs
@@ -14,7 +14,7 @@ namespace Funcky.Extensions
         public static IEnumerable<ValueWithLast<TSource>> WithLast<TSource>(this IEnumerable<TSource> source)
             => source switch
             {
-                IList<TSource> list => new ListWithSelector<TSource, ValueWithLast<TSource>>(list, ValueWithLast),
+                IList<TSource> list => ListWithSelector.Create(list, ValueWithLast),
                 _ => source.WithLastImplementation(),
             };
 

--- a/Funcky/Extensions/EnumerableExtensions/WithLast.cs
+++ b/Funcky/Extensions/EnumerableExtensions/WithLast.cs
@@ -1,3 +1,5 @@
+using Funcky.Internal;
+
 namespace Funcky.Extensions
 {
     public static partial class EnumerableExtensions
@@ -10,6 +12,17 @@ namespace Funcky.Extensions
         /// <returns>Returns a sequence mapping each element into a type which has an IsLast property which is true for the last element of the sequence.</returns>
         [Pure]
         public static IEnumerable<ValueWithLast<TSource>> WithLast<TSource>(this IEnumerable<TSource> source)
+            => source switch
+            {
+                IList<TSource> list => new ListWithSelector<TSource, ValueWithLast<TSource>>(list, ValueWithLast),
+                _ => source.WithLastImplementation(),
+            };
+
+        private static Func<TSource, int, ValueWithLast<TSource>> ValueWithLast<TSource>(IList<TSource> list)
+            => (value, index)
+                => new(value, index == list.Count - 1);
+
+        private static IEnumerable<ValueWithLast<TSource>> WithLastImplementation<TSource>(this IEnumerable<TSource> source)
         {
             using var enumerator = source.GetEnumerator();
 

--- a/Funcky/Extensions/EnumerableExtensions/WithPrevious.cs
+++ b/Funcky/Extensions/EnumerableExtensions/WithPrevious.cs
@@ -11,7 +11,7 @@ namespace Funcky.Extensions
             where TSource : notnull
             => source switch
             {
-                IList<TSource> list => new ListWithSelector.Create(list, ValueWithPrevious),
+                IList<TSource> list => ListWithSelector.Create(list, ValueWithPrevious),
                 _ => source.WithPreviousImplementation(),
             };
 

--- a/Funcky/Extensions/EnumerableExtensions/WithPrevious.cs
+++ b/Funcky/Extensions/EnumerableExtensions/WithPrevious.cs
@@ -1,3 +1,5 @@
+using Funcky.Internal;
+
 namespace Funcky.Extensions
 {
     public static partial class EnumerableExtensions
@@ -6,6 +8,22 @@ namespace Funcky.Extensions
         /// <exception cref="ArgumentNullException">Thrown when any value in <paramref name="source"/> is <see langword="null"/>.</exception>
         [Pure]
         public static IEnumerable<ValueWithPrevious<TSource>> WithPrevious<TSource>(this IEnumerable<TSource> source)
+            where TSource : notnull
+            => source switch
+            {
+                IList<TSource> list => new ListWithSelector<TSource, ValueWithPrevious<TSource>>(list, ValueWithPrevious),
+                _ => source.WithPreviousImplementation(),
+            };
+
+        private static Func<TSource, int, ValueWithPrevious<TSource>> ValueWithPrevious<TSource>(IList<TSource> list)
+            where TSource : notnull
+            => (value, index)
+                => new(value, IndexOfPrevious(index) < 0 ? Option<TSource>.None() : list[IndexOfPrevious(index)]);
+
+        private static int IndexOfPrevious(int index)
+            => index - 1;
+
+        private static IEnumerable<ValueWithPrevious<TSource>> WithPreviousImplementation<TSource>(this IEnumerable<TSource> source)
             where TSource : notnull
         {
             var previous = Option<TSource>.None();

--- a/Funcky/Extensions/EnumerableExtensions/WithPrevious.cs
+++ b/Funcky/Extensions/EnumerableExtensions/WithPrevious.cs
@@ -11,7 +11,7 @@ namespace Funcky.Extensions
             where TSource : notnull
             => source switch
             {
-                IList<TSource> list => new ListWithSelector<TSource, ValueWithPrevious<TSource>>(list, ValueWithPrevious),
+                IList<TSource> list => new ListWithSelector.Create(list, ValueWithPrevious),
                 _ => source.WithPreviousImplementation(),
             };
 

--- a/Funcky/Extensions/EnumerableExtensions/WithPrevious.cs
+++ b/Funcky/Extensions/EnumerableExtensions/WithPrevious.cs
@@ -18,7 +18,7 @@ namespace Funcky.Extensions
         private static Func<TSource, int, ValueWithPrevious<TSource>> ValueWithPrevious<TSource>(IList<TSource> list)
             where TSource : notnull
             => (value, index)
-                => new(value, IndexOfPrevious(index) < 0 ? Option<TSource>.None() : list[IndexOfPrevious(index)]);
+                => new(value, list.ElementAtOrNone(IndexOfPrevious(index)));
 
         private static int IndexOfPrevious(int index)
             => index - 1;

--- a/Funcky/Extensions/EnumerableExtensions/WithPrevious.cs
+++ b/Funcky/Extensions/EnumerableExtensions/WithPrevious.cs
@@ -17,8 +17,13 @@ namespace Funcky.Extensions
 
         private static Func<TSource, int, ValueWithPrevious<TSource>> ValueWithPrevious<TSource>(IList<TSource> list)
             where TSource : notnull
+#if OPTIMIZED_ELEMENT_AT
             => (value, index)
                 => new(value, list.ElementAtOrNone(IndexOfPrevious(index)));
+#else
+            => (value, index)
+                => new(value, IndexOfPrevious(index) < 0 ? Option<TSource>.None() : list[IndexOfPrevious(index)]);
+#endif
 
         private static int IndexOfPrevious(int index)
             => index - 1;

--- a/Funcky/Internal/ListWithIndex.cs
+++ b/Funcky/Internal/ListWithIndex.cs
@@ -1,0 +1,56 @@
+using System.Collections;
+
+namespace Funcky.Internal
+{
+    internal class ListWithIndex<TSource> : IList<ValueWithIndex<TSource>>
+    {
+        private readonly IList<TSource> _source;
+
+        public ListWithIndex(IList<TSource> source)
+            => _source = source;
+
+        public int Count
+            => _source.Count;
+
+        public bool IsReadOnly
+            => true;
+
+        public ValueWithIndex<TSource> this[int index]
+        {
+            get => new(_source[index], index);
+            set => throw new InvalidOperationException();
+        }
+
+        public void Add(ValueWithIndex<TSource> item)
+            => throw new InvalidOperationException();
+
+        public void Clear()
+            => throw new InvalidOperationException();
+
+        public bool Contains(ValueWithIndex<TSource> item)
+            => throw new InvalidOperationException();
+
+        public void CopyTo(ValueWithIndex<TSource>[] array, int arrayIndex)
+            => throw new InvalidOperationException();
+
+        public IEnumerator<ValueWithIndex<TSource>> GetEnumerator()
+            => _source
+                .Select(ValueWithIndex<TSource>.Create)
+                .GetEnumerator();
+
+        public int IndexOf(ValueWithIndex<TSource> item)
+            => throw new InvalidOperationException();
+
+        public void Insert(int index, ValueWithIndex<TSource> item)
+            => throw new InvalidOperationException();
+
+        public bool Remove(ValueWithIndex<TSource> item)
+            => throw new InvalidOperationException();
+
+        public void RemoveAt(int index)
+            => throw new InvalidOperationException();
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => GetEnumerator();
+    }
+}

--- a/Funcky/Internal/ListWithSelector.cs
+++ b/Funcky/Internal/ListWithSelector.cs
@@ -19,20 +19,20 @@ namespace Funcky.Internal
         public TResult this[int index]
         {
             get => _selector(_source[index], index);
-            set => throw new InvalidOperationException();
+            set => throw new NotSupportedException();
         }
 
         public void Add(TResult item)
-            => throw new InvalidOperationException();
+            => throw new NotSupportedException();
 
         public void Clear()
-            => throw new InvalidOperationException();
+            => throw new NotSupportedException();
 
         public bool Contains(TResult item)
-            => throw new InvalidOperationException();
+            => throw new NotSupportedException();
 
         public void CopyTo(TResult[] array, int arrayIndex)
-            => throw new InvalidOperationException();
+            => throw new NotSupportedException();
 
         public IEnumerator<TResult> GetEnumerator()
             => _source
@@ -40,16 +40,16 @@ namespace Funcky.Internal
                 .GetEnumerator();
 
         public int IndexOf(TResult item)
-            => throw new InvalidOperationException();
+            => throw new NotSupportedException();
 
         public void Insert(int index, TResult item)
-            => throw new InvalidOperationException();
+            => throw new NotSupportedException();
 
         public bool Remove(TResult item)
-            => throw new InvalidOperationException();
+            => throw new NotSupportedException();
 
         public void RemoveAt(int index)
-            => throw new InvalidOperationException();
+            => throw new NotSupportedException();
 
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();

--- a/Funcky/Internal/ListWithSelector.cs
+++ b/Funcky/Internal/ListWithSelector.cs
@@ -2,12 +2,13 @@ using System.Collections;
 
 namespace Funcky.Internal
 {
-    internal class ListWithIndex<TSource> : IList<ValueWithIndex<TSource>>
+    internal class ListWithSelector<TSource, TResult> : IList<TResult>
     {
         private readonly IList<TSource> _source;
+        private readonly Func<TSource, int, TResult> _selector;
 
-        public ListWithIndex(IList<TSource> source)
-            => _source = source;
+        public ListWithSelector(IList<TSource> source, Func<IList<TSource>, Func<TSource, int, TResult>> selector)
+            => (_source, _selector) = (source, selector(source));
 
         public int Count
             => _source.Count;
@@ -15,36 +16,36 @@ namespace Funcky.Internal
         public bool IsReadOnly
             => true;
 
-        public ValueWithIndex<TSource> this[int index]
+        public TResult this[int index]
         {
-            get => new(_source[index], index);
+            get => _selector(_source[index], index);
             set => throw new InvalidOperationException();
         }
 
-        public void Add(ValueWithIndex<TSource> item)
+        public void Add(TResult item)
             => throw new InvalidOperationException();
 
         public void Clear()
             => throw new InvalidOperationException();
 
-        public bool Contains(ValueWithIndex<TSource> item)
+        public bool Contains(TResult item)
             => throw new InvalidOperationException();
 
-        public void CopyTo(ValueWithIndex<TSource>[] array, int arrayIndex)
+        public void CopyTo(TResult[] array, int arrayIndex)
             => throw new InvalidOperationException();
 
-        public IEnumerator<ValueWithIndex<TSource>> GetEnumerator()
+        public IEnumerator<TResult> GetEnumerator()
             => _source
-                .Select(ValueWithIndex<TSource>.Create)
+                .Select(_selector)
                 .GetEnumerator();
 
-        public int IndexOf(ValueWithIndex<TSource> item)
+        public int IndexOf(TResult item)
             => throw new InvalidOperationException();
 
-        public void Insert(int index, ValueWithIndex<TSource> item)
+        public void Insert(int index, TResult item)
             => throw new InvalidOperationException();
 
-        public bool Remove(ValueWithIndex<TSource> item)
+        public bool Remove(TResult item)
             => throw new InvalidOperationException();
 
         public void RemoveAt(int index)

--- a/Funcky/Internal/ListWithSelector.cs
+++ b/Funcky/Internal/ListWithSelector.cs
@@ -2,6 +2,12 @@ using System.Collections;
 
 namespace Funcky.Internal
 {
+    internal class ListWithSelector
+    {
+        public static ListWithSelector<TSource, TResult> Create<TSource, TResult>(IList<TSource> source, Func<IList<TSource>, Func<TSource, int, TResult>> selector)
+            => new(source, selector);
+    }
+
     internal class ListWithSelector<TSource, TResult> : IList<TResult>
     {
         private readonly IList<TSource> _source;

--- a/Funcky/PublicAPI.Unshipped.txt
+++ b/Funcky/PublicAPI.Unshipped.txt
@@ -4,6 +4,7 @@ static Funcky.Extensions.QueueExtensions.DequeueOrNone<TItem>(this System.Collec
 static Funcky.Extensions.QueueExtensions.DequeueOrNone<TItem>(this System.Collections.Generic.Queue<TItem>! queue) -> Funcky.Monads.Option<TItem>
 static Funcky.Extensions.QueueExtensions.PeekOrNone<TItem>(this System.Collections.Concurrent.ConcurrentQueue<TItem>! concurrentQueue) -> Funcky.Monads.Option<TItem>
 static Funcky.Extensions.QueueExtensions.PeekOrNone<TItem>(this System.Collections.Generic.Queue<TItem>! queue) -> Funcky.Monads.Option<TItem>
+static Funcky.Extensions.ValueWithIndex<TValue>.Create(TValue value, int index) -> Funcky.Extensions.ValueWithIndex<TValue>
 static Funcky.Sequence.Return<TItem>(params TItem[]! items) -> System.Collections.Generic.IEnumerable<TItem>!
 static Funcky.Sequence.Successors<TItem>(Funcky.Monads.Option<TItem> first, System.Func<TItem, Funcky.Monads.Option<TItem>>! successor) -> System.Collections.Generic.IEnumerable<TItem>!
 static Funcky.Sequence.Successors<TItem>(Funcky.Monads.Option<TItem> first, System.Func<TItem, TItem>! successor) -> System.Collections.Generic.IEnumerable<TItem>!

--- a/Funcky/PublicAPI.Unshipped.txt
+++ b/Funcky/PublicAPI.Unshipped.txt
@@ -4,7 +4,6 @@ static Funcky.Extensions.QueueExtensions.DequeueOrNone<TItem>(this System.Collec
 static Funcky.Extensions.QueueExtensions.DequeueOrNone<TItem>(this System.Collections.Generic.Queue<TItem>! queue) -> Funcky.Monads.Option<TItem>
 static Funcky.Extensions.QueueExtensions.PeekOrNone<TItem>(this System.Collections.Concurrent.ConcurrentQueue<TItem>! concurrentQueue) -> Funcky.Monads.Option<TItem>
 static Funcky.Extensions.QueueExtensions.PeekOrNone<TItem>(this System.Collections.Generic.Queue<TItem>! queue) -> Funcky.Monads.Option<TItem>
-static Funcky.Extensions.ValueWithIndex<TValue>.Create(TValue value, int index) -> Funcky.Extensions.ValueWithIndex<TValue>
 static Funcky.Sequence.Return<TItem>(params TItem[]! items) -> System.Collections.Generic.IEnumerable<TItem>!
 static Funcky.Sequence.Successors<TItem>(Funcky.Monads.Option<TItem> first, System.Func<TItem, Funcky.Monads.Option<TItem>>! successor) -> System.Collections.Generic.IEnumerable<TItem>!
 static Funcky.Sequence.Successors<TItem>(Funcky.Monads.Option<TItem> first, System.Func<TItem, TItem>! successor) -> System.Collections.Generic.IEnumerable<TItem>!


### PR DESCRIPTION
Implementation of an optimization to `WithIndex`, `WithFirst`, `WithLast` and `WithPrevious` for Inputs which derive from `IList`.

This allows optimized access via `ElementAt` in constant time `ILists` which are transformed with those extension-functions.