### PR TITLE
Improve DiagnosticId Names.

### DIFF
--- a/Funcky.Analyzers/Funcky.Analyzers.Test/EnumerableRepeatNeverTest.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers.Test/EnumerableRepeatNeverTest.cs
@@ -17,7 +17,7 @@ namespace Funcky.Analyzers.Test
         public async Task UsingEnumerableRepeatNeverShowsTheSequenceReturnDiagnostic()
         {
             var expectedDiagnostic = VerifyCS
-                .Diagnostic(nameof(EnumerableRepeatNeverAnalyzer))
+                .Diagnostic(EnumerableRepeatNeverAnalyzer.DiagnosticId)
                 .WithSpan(10, 26, 10, 62)
                 .WithArguments("\"Hello world!\"", "string");
 
@@ -28,7 +28,7 @@ namespace Funcky.Analyzers.Test
         public async Task UsingEnumerableRepeatNeverViaConstantShowsTheSequenceReturnDiagnostic()
         {
             var expectedDiagnostic = VerifyCS
-                .Diagnostic(nameof(EnumerableRepeatNeverAnalyzer))
+                .Diagnostic(EnumerableRepeatNeverAnalyzer.DiagnosticId)
                 .WithSpan(11, 26, 11, 66)
                 .WithArguments("\"Hello world!\"", "string");
 
@@ -39,7 +39,7 @@ namespace Funcky.Analyzers.Test
         public async Task UsingEnumerableRepeatNeverWorksWithDifferentTypes()
         {
             var expectedDiagnostic = VerifyCS
-                .Diagnostic(nameof(EnumerableRepeatNeverAnalyzer))
+                .Diagnostic(EnumerableRepeatNeverAnalyzer.DiagnosticId)
                 .WithSpan(10, 26, 10, 52)
                 .WithArguments("1337", "int");
 

--- a/Funcky.Analyzers/Funcky.Analyzers.Test/EnumerableRepeatOnceTest.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers.Test/EnumerableRepeatOnceTest.cs
@@ -17,7 +17,7 @@ namespace Funcky.Analyzers.Test
         public async Task UsingEnumerableRepeatOnceShowsTheSequenceReturnDiagnostic()
         {
             var expectedDiagnostic = VerifyCS
-                .Diagnostic(nameof(EnumerableRepeatOnceAnalyzer))
+                .Diagnostic(EnumerableRepeatOnceAnalyzer.DiagnosticId)
                 .WithSpan(17, 26, 17, 62)
                 .WithArguments("\"Hello world!\"");
 
@@ -28,7 +28,7 @@ namespace Funcky.Analyzers.Test
         public async Task UsingEnumerableRepeatOnceViaConstantShowsTheSequenceReturnDiagnostic()
         {
             var expectedDiagnostic = VerifyCS
-                .Diagnostic(nameof(EnumerableRepeatOnceAnalyzer))
+                .Diagnostic(EnumerableRepeatOnceAnalyzer.DiagnosticId)
                 .WithSpan(18, 26, 18, 65)
                 .WithArguments("\"Hello world!\"");
 

--- a/Funcky.Analyzers/Funcky.Analyzers/DiagnosticName.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers/DiagnosticName.cs
@@ -1,0 +1,9 @@
+namespace Funcky.Analyzers
+{
+    internal static class DiagnosticName
+    {
+        public const string Prefix = "λ";
+
+        public const string Usage = "10";
+    }
+}

--- a/Funcky.Analyzers/Funcky.Analyzers/EnumerableRepeatNeverAnalyzer.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers/EnumerableRepeatNeverAnalyzer.cs
@@ -11,14 +11,14 @@ namespace Funcky.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class EnumerableRepeatNeverAnalyzer : DiagnosticAnalyzer
     {
-        public const string DiagnosticId = nameof(EnumerableRepeatNeverAnalyzer);
+        public const string DiagnosticId = $"{DiagnosticName.Prefix}{DiagnosticName.Usage}02";
         private const string Category = nameof(Funcky);
 
         private static readonly LocalizableString Title = LoadFromResource(nameof(EnumerableRepeatNeverAnalyzerTitle));
         private static readonly LocalizableString MessageFormat = LoadFromResource(nameof(EnumerableRepeatNeverAnalyzerMessageFormat));
         private static readonly LocalizableString Description = LoadFromResource(nameof(EnumerableRepeatNeverAnalyzerDescription));
 
-        private static readonly DiagnosticDescriptor Rule = new(nameof(EnumerableRepeatNeverAnalyzer), Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
+        private static readonly DiagnosticDescriptor Rule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/Funcky.Analyzers/Funcky.Analyzers/EnumerableRepeatOnceAnalyzer.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers/EnumerableRepeatOnceAnalyzer.cs
@@ -11,14 +11,14 @@ namespace Funcky.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class EnumerableRepeatOnceAnalyzer : DiagnosticAnalyzer
     {
-        public const string DiagnosticId = nameof(EnumerableRepeatOnceAnalyzer);
+        public const string DiagnosticId = $"{DiagnosticName.Prefix}{DiagnosticName.Usage}01";
         private const string Category = nameof(Funcky);
 
         private static readonly LocalizableString Title = LoadFromResource(nameof(EnumerableRepeatOnceAnalyzerTitle));
         private static readonly LocalizableString MessageFormat = LoadFromResource(nameof(EnumerableRepeatOnceAnalyzerMessageFormat));
         private static readonly LocalizableString Description = LoadFromResource(nameof(EnumerableRepeatOnceAnalyzerDescription));
 
-        private static readonly DiagnosticDescriptor Rule = new(nameof(EnumerableRepeatOnceAnalyzer), Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
+        private static readonly DiagnosticDescriptor Rule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 


### PR DESCRIPTION
Fixes #473
* Prefix will be λ
* Category Usage is 1000 - 1100
* The present Diagnostics are λ1001 and λ1002