### PR TITLE
Memoize experiment

### DIFF
--- a/Funcky.Test/Extensions/EnumerableExtensions/MemoizeTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/MemoizeTest.cs
@@ -1,0 +1,51 @@
+using Funcky.Test.TestUtils;
+using Xunit.Sdk;
+
+namespace Funcky.Test.Extensions.EnumerableExtensions;
+
+public sealed class MemoizeTest
+{
+    [Fact]
+    public void MemoizeIsEnumeratedLazily()
+    {
+        var doNotEnumerate = new FailOnEnumerationSequence<object>();
+
+        _ = doNotEnumerate.Memoize();
+    }
+
+    [Fact]
+    public void YouCanOnlyEnumerateAFragileSequenceOnce()
+    {
+        var doNotEnumerateTwice = new DoNotEnumerateTwice<int>(Sequence.Return(1, 42, 100));
+
+        doNotEnumerateTwice.ForEach(NoOperation);
+
+        Assert.Throws<XunitException>(() => doNotEnumerateTwice.ForEach(NoOperation));
+    }
+
+    [Fact]
+    public void WeCanSafelyEnumerateTwiceOnAFragileSequence()
+    {
+        var memoized = new DoNotEnumerateTwice<int>(Sequence.Return(1, 42, 100)).Memoize();
+
+        memoized.ForEach(NoOperation);
+        memoized.ForEach(NoOperation);
+    }
+
+    [Fact]
+    public void MemoizeCanPartiallyEnumerate()
+    {
+        var doNotEnumerateTwice = new DoNotEnumerateTwice<int>(Sequence.Return(1, 42, 100));
+        var memoized = doNotEnumerateTwice.Memoize();
+
+        Assert.Equal(0, doNotEnumerateTwice.EnumerationIndex);
+        _ = memoized.First();
+        Assert.Equal(1, doNotEnumerateTwice.EnumerationIndex);
+        _ = memoized.First();
+        Assert.Equal(1, doNotEnumerateTwice.EnumerationIndex);
+        _ = memoized.Skip(1).First();
+        Assert.Equal(2, doNotEnumerateTwice.EnumerationIndex);
+        memoized.ForEach(NoOperation);
+        Assert.Equal(3, doNotEnumerateTwice.EnumerationIndex);
+    }
+}

--- a/Funcky.Test/TestUtils/DoNotEnumerateTwice.cs
+++ b/Funcky.Test/TestUtils/DoNotEnumerateTwice.cs
@@ -1,0 +1,40 @@
+using System.Collections;
+using Xunit.Sdk;
+
+namespace Funcky.Test.TestUtils;
+
+public sealed class DoNotEnumerateTwice<T> : IEnumerable<T>
+    where T : notnull
+{
+    private readonly Queue<T> _source;
+    private bool _first;
+
+    public DoNotEnumerateTwice(IEnumerable<T> source)
+    {
+        _source = new Queue<T>(source);
+        _first = true;
+    }
+
+    public int EnumerationIndex { get; private set; }
+
+    public IEnumerator<T> GetEnumerator()
+    {
+        if (!_first)
+        {
+            throw new XunitException($"Multiple enumeration in {nameof(DoNotEnumerateTwice<T>)}");
+        }
+
+        _first = false;
+
+        while (_source.Count > 0)
+        {
+            EnumerationIndex++;
+            yield return _source.Dequeue();
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+}

--- a/Funcky.Test/TestUtils/FailOnEnumerationSequence.cs
+++ b/Funcky.Test/TestUtils/FailOnEnumerationSequence.cs
@@ -6,9 +6,26 @@ namespace Funcky.Test.TestUtils
     internal sealed class FailOnEnumerationSequence<T> : IEnumerable<T>
     {
         public IEnumerator<T> GetEnumerator()
-            => throw new XunitException("Sequence was unexpectedly enumerated.");
+            => new FailOnEnumerationEnumerator<T>();
 
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
+    }
+
+    internal sealed class FailOnEnumerationEnumerator<T> : IEnumerator<T>
+    {
+        public T Current => throw new NotImplementedException();
+
+        object IEnumerator.Current => throw new NotImplementedException();
+
+        public void Dispose()
+        {
+        }
+
+        public bool MoveNext()
+            => throw new XunitException("Sequence was unexpectedly enumerated.");
+
+        public void Reset()
+            => throw new XunitException("Sequence was unexpectedly reset.");
     }
 }

--- a/Funcky/Extensions/EnumerableExtensions/Memoize.cs
+++ b/Funcky/Extensions/EnumerableExtensions/Memoize.cs
@@ -1,0 +1,61 @@
+#pragma warning disable IDISP005 // Return type should indicate that the value should be disposed.
+#pragma warning disable IDISP006 // Implement IDisposable.
+#pragma warning disable IDISP009 // Add IDisposable interface.
+
+using System.Collections;
+
+namespace Funcky.Extensions
+{
+    public static partial class EnumerableExtensions
+    {
+        [Pure]
+        public static IReadOnlyList<T> Memoize<T>(this IEnumerable<T> sequence)
+            => sequence switch
+            {
+                IReadOnlyList<T> list => list,
+                _ => new BufferedSequence<T>(sequence),
+            };
+
+        internal sealed class BufferedSequence<T> : IReadOnlyList<T>
+        {
+            private readonly IEnumerator<T> _enumerator;
+            private readonly List<T> _cache = new();
+            private bool _disposed;
+
+            public BufferedSequence(IEnumerable<T> sequence)
+                => _enumerator = sequence.GetEnumerator();
+
+            public int Count => _disposed
+                ? _cache.Count
+                : throw new NotSupportedException("not enumerated completely");
+
+            public T this[int index] => index >= 0 && index < _cache.Count
+                ? _cache[index]
+                : throw new NotSupportedException("not enumerated (yet)");
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                foreach (var element in _cache)
+                {
+                    yield return element;
+                }
+
+                while (_enumerator.MoveNext())
+                {
+                    var current = _enumerator.Current;
+                    _cache.Add(current);
+                    yield return current;
+                }
+
+                _enumerator.Dispose();
+                _disposed = true;
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+                => GetEnumerator();
+
+            public void Dispose()
+                => _enumerator.Dispose();
+        }
+    }
+}

--- a/Funcky/PublicAPI.Unshipped.txt
+++ b/Funcky/PublicAPI.Unshipped.txt
@@ -44,6 +44,7 @@ static Funcky.EitherOrBoth<TLeft, TRight>.operator ==(Funcky.EitherOrBoth<TLeft,
 static Funcky.Extensions.EnumerableExtensions.Chunk<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<System.Collections.Generic.IReadOnlyList<TSource>!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 static Funcky.Extensions.EnumerableExtensions.Chunk<TSource>(System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IReadOnlyList<TSource>!>!
 static Funcky.Extensions.EnumerableExtensions.ForEach<T>(this System.Collections.Generic.IEnumerable<T>! elements, System.Action<T>! action) -> Funcky.Unit
+static Funcky.Extensions.EnumerableExtensions.Memoize<T>(this System.Collections.Generic.IEnumerable<T>! sequence) -> System.Collections.Generic.IReadOnlyList<T>!
 static Funcky.Extensions.EnumerableExtensions.ZipLongest<TLeft, TRight, TResult>(this System.Collections.Generic.IEnumerable<TLeft>! left, System.Collections.Generic.IEnumerable<TRight>! right, System.Func<Funcky.EitherOrBoth<TLeft, TRight>, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 static Funcky.Extensions.EnumerableExtensions.ZipLongest<TLeft, TRight>(this System.Collections.Generic.IEnumerable<TLeft>! left, System.Collections.Generic.IEnumerable<TRight>! right) -> System.Collections.Generic.IEnumerable<Funcky.EitherOrBoth<TLeft, TRight>>!
 static Funcky.Functional.False() -> bool


### PR DESCRIPTION
Addresses #140 - There is no  really clean solution to this:

The problem is:

1.) To keep the innner state you need to hold a reference to the Enumerator of the underlying sequence.
2.) You have to keep it in the Enumerable which leads to a Member which needs to be disposed.
3.) A class which has disposable members should implement IDisposable

Since an IEnumerable is not an IDisposable, you have to deal with a bad case of serving two masters.

* This implementation is trivially and does Dispose correctly when the underlying sequence is enumerate completley at some point.
* It offers a Dispose function to Dispose manually, in the cases you do not enumerate the whole sequence.

This implementation should help us a way forward.

