### PR TITLE
Improve `dotnet restore` performance on windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,13 @@ jobs:
       name: 'Install .NET SDK 5.0'
       with:
         dotnet-version: '5.0.x'
+
+    # Workaround for slow `dotnet restore` performance.
+    # See: https://github.com/actions/virtual-environments/issues/3577#issuecomment-1013139027
+    - name: Use clean NuGet config
+      if: success() && runner.os == 'Windows'
+      run: dotnet new nugetconfig
+
     - name: Restore dependencies
       run: dotnet restore
     - name: Build


### PR DESCRIPTION
restore still takes longer on windows compared to linux, but it's a bit faster than before.