### PR TITLE
Use materialize to avoid multiple enumeration in CycleRange and RepeatRange

### DIFF
--- a/Funcky.Test/Sequence/CycleRangeTest.cs
+++ b/Funcky.Test/Sequence/CycleRangeTest.cs
@@ -22,5 +22,16 @@ namespace Funcky.Test
                 .CycleRange(sequence.Get)
                 .IsSequenceRepeating(sequence.Get)
                 .NTimes(arbitraryElements.Get);
+
+        [Property]
+        public void CycleRangeEnumeratesUnderlyingEnumerableOnlyOnce(NonEmptySet<int> sequence)
+        {
+            var enumerateOnce = new EnumerateOnce<int>(sequence.Get);
+
+            Sequence
+                .CycleRange(enumerateOnce)
+                .Take(sequence.Get.Count * 3)
+                .ForEach(NoOperation);
+        }
     }
 }

--- a/Funcky.Test/Sequence/RepeatRangeTest.cs
+++ b/Funcky.Test/Sequence/RepeatRangeTest.cs
@@ -22,5 +22,15 @@ namespace Funcky.Test
                 .RepeatRange(list, count.Get)
                 .IsSequenceRepeating(list)
                 .NTimes(count.Get);
+
+        [Property]
+        public void RepeatRangeEnumeratesUnderlyingEnumerableOnlyOnce(NonEmptySet<int> sequence)
+        {
+            var enumerateOnce = new EnumerateOnce<int>(sequence.Get);
+
+            Sequence
+                .RepeatRange(enumerateOnce, 3)
+                .ForEach(NoOperation);
+        }
     }
 }

--- a/Funcky.Test/TestUtils/EnumerateOnce.cs
+++ b/Funcky.Test/TestUtils/EnumerateOnce.cs
@@ -20,7 +20,7 @@ public class EnumerateOnce<T> : IEnumerable<T>
         {
             var maybeValue = _once.DequeueOrNone();
 
-            if (maybeValue.Match(false, True))
+            if (maybeValue.Match(none: false, some: True))
             {
                 yield return maybeValue.GetOrElse(() => throw new Exception("cannot happen!"));
             }

--- a/Funcky.Test/TestUtils/EnumerateOnce.cs
+++ b/Funcky.Test/TestUtils/EnumerateOnce.cs
@@ -1,0 +1,47 @@
+using System.Collections;
+using Xunit.Sdk;
+
+namespace Funcky.Test.TestUtils;
+
+public class EnumerateOnce<T> : IEnumerable<T>
+    where T : notnull
+{
+    private readonly Queue<T> _once;
+    private bool _first = true;
+
+    public EnumerateOnce(IEnumerable<T> sequence)
+        => _once = new Queue<T>(sequence);
+
+    public IEnumerator<T> GetEnumerator()
+    {
+        ValidateFirst();
+
+        while (true)
+        {
+            var maybeValue = _once.DequeueOrNone();
+
+            if (maybeValue.Match(false, True))
+            {
+                yield return maybeValue.GetOrElse(() => throw new Exception("cannot happen!"));
+            }
+            else
+            {
+                break;
+            }
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private void ValidateFirst()
+    {
+        if (_first)
+        {
+            _first = false;
+        }
+        else
+        {
+            throw new XunitException("Sequence was unexpectedly enumerated a second time.");
+        }
+    }
+}

--- a/Funcky/Sequence/Sequence.CycleRange.cs
+++ b/Funcky/Sequence/Sequence.CycleRange.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace Funcky
 {
     public static partial class Sequence
@@ -11,15 +13,20 @@ namespace Funcky
         [Pure]
         public static IEnumerable<TItem> CycleRange<TItem>(IEnumerable<TItem> sequence)
             where TItem : notnull
-        {
-            var list = sequence.ToList();
+            => CycleSequenceIfNotEmpty(sequence.Materialize());
 
-            if (list.None())
-            {
-                throw new ArgumentException("An empty sequence cannot be cycled", nameof(sequence));
-            }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static IEnumerable<TItem> CycleSequenceIfNotEmpty<TItem>(IReadOnlyCollection<TItem> sequence)
+            where TItem : notnull
+            => sequence.Count != 0
+                ? ProjectCycles(sequence)
+                : throw new ArgumentException("An empty sequence cannot be cycled", nameof(sequence));
 
-            return Cycle(sequence).SelectMany(Identity);
-        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static IEnumerable<TItem> ProjectCycles<TItem>(IReadOnlyCollection<TItem> list)
+            where TItem : notnull
+            => from cycle in Cycle(list)
+               from element in cycle
+               select element;
     }
 }

--- a/Funcky/Sequence/Sequence.RepeatRange.cs
+++ b/Funcky/Sequence/Sequence.RepeatRange.cs
@@ -12,8 +12,12 @@ namespace Funcky
         [Pure]
         public static IEnumerable<TItem> RepeatRange<TItem>(IEnumerable<TItem> sequence, int count)
             where TItem : notnull
+            => RepeatCollection(sequence.Materialize(), count);
+
+        private static IEnumerable<TItem> RepeatCollection<TItem>(IReadOnlyCollection<TItem> collection, int count)
+            where TItem : notnull
             => Enumerable
                 .Repeat(Unit.Value, count)
-                .SelectMany(_ => sequence);
+                .SelectMany(_ => collection);
     }
 }


### PR DESCRIPTION
Fixes #532

Moved to funcky 3 because we want the optimization of `Materialize()` available in funcky3