### PR TITLE
Add `Option.None<T>` for Funcky 2.x

### DIFF
--- a/Funcky.Analyzers/Funcky.Analyzers.Test/OptionNoneMethodGroupTest.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers.Test/OptionNoneMethodGroupTest.cs
@@ -1,0 +1,68 @@
+using Xunit;
+using VerifyCS = Funcky.Analyzers.Test.CSharpCodeFixVerifier<Funcky.BuiltinAnalyzers.OptionNoneMethodGroupAnalyzer, Funcky.BuiltinAnalyzers.OptionNoneCodeFix>;
+
+namespace Funcky.Analyzers.Test;
+
+public sealed class OptionNoneMethodGroupTest
+{
+    private const string OptionCode = @"namespace Funcky.Monads
+{
+    public readonly struct Option<TItem>
+    {
+        public static Option<TItem> None() => default;
+    }
+
+    public static class Option
+    {
+        public static Option<TItem> None<TItem>() => default;
+    }
+}";
+
+    [Fact]
+    public async Task ReplacesOptionOfTNoneWithOptionNone()
+    {
+        const string inputCode = @"
+using Funcky.Monads;
+
+public static class C
+{
+    public static void M()
+    {
+        System.Func<Option<int>> func = Option<int>.None;
+    }
+}";
+
+        const string fixedCode = @"
+using Funcky.Monads;
+
+public static class C
+{
+    public static void M()
+    {
+        System.Func<Option<int>> func = Option.None<int>;
+    }
+}";
+
+        await VerifyCS.VerifyCodeFixAsync(
+            inputCode + Environment.NewLine + OptionCode,
+            VerifyCS.Diagnostic().WithSpan(8, 41, 8, 57),
+            fixedCode + Environment.NewLine + OptionCode);
+    }
+
+    [Fact]
+    public async Task ReportsNoDiagnosticForInvocation()
+    {
+        const string inputCode = @"
+using Funcky.Monads;
+
+public static class C
+{
+    public static void M()
+    {
+        Option<int> x = Option<int>.None();
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(inputCode + Environment.NewLine + OptionCode);
+    }
+}

--- a/Funcky.Analyzers/Funcky.Analyzers.Test/OptionNoneMethodGroupTest.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers.Test/OptionNoneMethodGroupTest.cs
@@ -45,7 +45,7 @@ public static class C
 
         await VerifyCS.VerifyCodeFixAsync(
             inputCode + Environment.NewLine + OptionCode,
-            VerifyCS.Diagnostic().WithSpan(8, 41, 8, 57),
+            VerifyCS.Diagnostic().WithSpan(8, 41, 8, 57).WithArguments("int"),
             fixedCode + Environment.NewLine + OptionCode);
     }
 

--- a/Funcky.Analyzers/Funcky.Analyzers/EnumerableRepeatNeverAnalyzer.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers/EnumerableRepeatNeverAnalyzer.cs
@@ -19,7 +19,7 @@ namespace Funcky.Analyzers
         private static readonly LocalizableString MessageFormat = LoadFromResource(nameof(EnumerableRepeatNeverAnalyzerMessageFormat));
         private static readonly LocalizableString Description = LoadFromResource(nameof(EnumerableRepeatNeverAnalyzerDescription));
 
-        private static readonly DiagnosticDescriptor Rule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/Funcky.Analyzers/Funcky.Analyzers/EnumerableRepeatOnceAnalyzer.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers/EnumerableRepeatOnceAnalyzer.cs
@@ -19,7 +19,7 @@ namespace Funcky.Analyzers
         private static readonly LocalizableString MessageFormat = LoadFromResource(nameof(EnumerableRepeatOnceAnalyzerMessageFormat));
         private static readonly LocalizableString Description = LoadFromResource(nameof(EnumerableRepeatOnceAnalyzerDescription));
 
-        private static readonly DiagnosticDescriptor Rule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/Funcky.Analyzers/Funcky.Analyzers/JoinToStringEmptyAnalyzer.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers/JoinToStringEmptyAnalyzer.cs
@@ -22,7 +22,7 @@ public sealed class JoinToStringEmptyAnalyzer : DiagnosticAnalyzer
 
     private static readonly LocalizableString Description = LoadFromResource(nameof(JoinToStringEmptyAnalyzerDescription));
 
-    private static readonly DiagnosticDescriptor Rule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
+    private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/Funcky.Analyzers/Funcky.Analyzers/UseWithArgumentNamesAnalyzer.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers/UseWithArgumentNamesAnalyzer.cs
@@ -14,7 +14,7 @@ namespace Funcky.Analyzers
 
         private const string AttributeFullName = "Funcky.CodeAnalysis.UseWithArgumentNamesAttribute";
 
-        private static readonly DiagnosticDescriptor Descriptor = new(
+        private static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
             id: DiagnosticId,
             title: Resources.UseWithArgumentNamesAnalyzerAnalyzerTitle,
             messageFormat: Resources.UseWithArgumentNamesAnalyzerMessageFormat,

--- a/Funcky.Analyzers/Funcky.BuiltinAnalyzers/AnalyzerReleases.Shipped.md
+++ b/Funcky.Analyzers/Funcky.BuiltinAnalyzers/AnalyzerReleases.Shipped.md
@@ -1,0 +1,2 @@
+﻿; Shipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/Funcky.Analyzers/Funcky.BuiltinAnalyzers/AnalyzerReleases.Unshipped.md
+++ b/Funcky.Analyzers/Funcky.BuiltinAnalyzers/AnalyzerReleases.Unshipped.md
@@ -3,7 +3,7 @@
 
 ### New Rules
 
-| Rule ID | Category           | Severity | Notes                         |
-|---------|--------------------|----------|-------------------------------|
-| λ0001   | Funcky             | Error    | TryGetValueAnalyzer           |
-| λ0002   | Funcky.Deprecation | Warning  | OptionNoneMethodGroupAnalyzer |
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+λ0001 | Funcky | Error | TryGetValueAnalyzer
+λ0002 | Funcky.Deprecation | Warning | OptionNoneMethodGroupAnalyzer

--- a/Funcky.Analyzers/Funcky.BuiltinAnalyzers/AnalyzerReleases.Unshipped.md
+++ b/Funcky.Analyzers/Funcky.BuiltinAnalyzers/AnalyzerReleases.Unshipped.md
@@ -3,6 +3,7 @@
 
 ### New Rules
 
-| Rule ID | Category | Severity | Notes               |
-|---------|----------|----------|---------------------|
-| λ0001   | Funcky   | Error    | TryGetValueAnalyzer |
+| Rule ID | Category           | Severity | Notes                         |
+|---------|--------------------|----------|-------------------------------|
+| λ0001   | Funcky             | Error    | TryGetValueAnalyzer           |
+| λ0002   | Funcky.Deprecation | Warning  | OptionNoneMethodGroupAnalyzer |

--- a/Funcky.Analyzers/Funcky.BuiltinAnalyzers/CompilationExtensions.cs
+++ b/Funcky.Analyzers/Funcky.BuiltinAnalyzers/CompilationExtensions.cs
@@ -5,4 +5,6 @@ namespace Funcky.BuiltinAnalyzers;
 internal static class CompilationExtensions
 {
     public static INamedTypeSymbol? GetOptionOfTType(this Compilation compilation) => compilation.GetTypeByMetadataName("Funcky.Monads.Option`1");
+
+    public static INamedTypeSymbol? GetOptionType(this Compilation compilation) => compilation.GetTypeByMetadataName("Funcky.Monads.Option");
 }

--- a/Funcky.Analyzers/Funcky.BuiltinAnalyzers/Funcky.BuiltinAnalyzers.csproj
+++ b/Funcky.Analyzers/Funcky.BuiltinAnalyzers/Funcky.BuiltinAnalyzers.csproj
@@ -11,6 +11,6 @@
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="3.7.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" VersionOverride="3.7.0" />
         <!-- Microsoft.CodeAnalysis.CSharp 3.7.0 comes with an older, buggy version of Microsoft.CodeAnalysis.Analyzers -->
-        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" VersionOverride="3.3.3" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" VersionOverride="3.3.3" />
     </ItemGroup>
 </Project>

--- a/Funcky.Analyzers/Funcky.BuiltinAnalyzers/Funcky.BuiltinAnalyzers.csproj
+++ b/Funcky.Analyzers/Funcky.BuiltinAnalyzers/Funcky.BuiltinAnalyzers.csproj
@@ -9,6 +9,7 @@
         <!-- We use 2.7.0 for compatibility with VS 2019 and .NET Core SDK 3.x.
              See https://docs.microsoft.com/en-us/visualstudio/extensibility/roslyn-version-support for VS compatibility.-->
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="3.7.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" VersionOverride="3.7.0" />
         <!-- Microsoft.CodeAnalysis.CSharp 3.7.0 comes with an older, buggy version of Microsoft.CodeAnalysis.Analyzers -->
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" VersionOverride="3.3.3" PrivateAssets="all" />
     </ItemGroup>

--- a/Funcky.Analyzers/Funcky.BuiltinAnalyzers/Funcky.BuiltinAnalyzers.csproj
+++ b/Funcky.Analyzers/Funcky.BuiltinAnalyzers/Funcky.BuiltinAnalyzers.csproj
@@ -11,6 +11,6 @@
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="3.7.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" VersionOverride="3.7.0" />
         <!-- Microsoft.CodeAnalysis.CSharp 3.7.0 comes with an older, buggy version of Microsoft.CodeAnalysis.Analyzers -->
-        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" VersionOverride="3.3.3" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" VersionOverride="3.3.3" PrivateAssets="all" />
     </ItemGroup>
 </Project>

--- a/Funcky.Analyzers/Funcky.BuiltinAnalyzers/OptionNoneMethodGroupAnalyzer.cs
+++ b/Funcky.Analyzers/Funcky.BuiltinAnalyzers/OptionNoneMethodGroupAnalyzer.cs
@@ -10,8 +10,8 @@ public sealed class OptionNoneMethodGroupAnalyzer : DiagnosticAnalyzer
 {
     public static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
         id: "λ0002",
-        title: "Prefer Option.None<T>() over Option<T>.None() when used as a method group.",
-        messageFormat: "Use Option.None<{0}> instead of Option<{0}>.None.",
+        title: "Prefer Option.None<T>() over Option<T>.None() when used as a method group",
+        messageFormat: "Use Option.None<{0}> instead of Option<{0}>.None",
         category: "Funcky.Deprecation",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,

--- a/Funcky.Analyzers/Funcky.BuiltinAnalyzers/OptionNoneMethodGroupAnalyzer.cs
+++ b/Funcky.Analyzers/Funcky.BuiltinAnalyzers/OptionNoneMethodGroupAnalyzer.cs
@@ -8,7 +8,7 @@ namespace Funcky.BuiltinAnalyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class OptionNoneMethodGroupAnalyzer : DiagnosticAnalyzer
 {
-    public static readonly DiagnosticDescriptor Descriptor = new(
+    public static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
         id: "λ0002",
         title: "Prefer Option.None<T>() over Option<T>.None() when used as a method group.",
         messageFormat: "Use Option.None<{0}> instead of Option<{0}>.None.",

--- a/Funcky.Analyzers/Funcky.BuiltinAnalyzers/OptionNoneMethodGroupAnalyzer.cs
+++ b/Funcky.Analyzers/Funcky.BuiltinAnalyzers/OptionNoneMethodGroupAnalyzer.cs
@@ -1,0 +1,52 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Funcky.BuiltinAnalyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class OptionNoneMethodGroupAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor Descriptor = new(
+        id: "λ0002",
+        title: "Prefer Option.None<T>() over Option<T>.None() when used as a method group.",
+        messageFormat: "Use Option.None<{0}> instead of Option<{0}>.None.",
+        category: "Funcky.Deprecation",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Funcky 3 changes Option<T>.None to a property, which will break method groups.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.RegisterCompilationStartAction(OnCompilationStart);
+    }
+
+    private static void OnCompilationStart(CompilationStartAnalysisContext context)
+    {
+        if (context.Compilation.GetOptionType() is not null && context.Compilation.GetOptionOfTType() is { } optionOfTType)
+        {
+            context.RegisterOperationAction(AnalyzeInvocation(optionOfTType), OperationKind.MethodReference);
+        }
+    }
+
+    private static Action<OperationAnalysisContext> AnalyzeInvocation(INamedTypeSymbol optionOfTType)
+        => context
+            =>
+            {
+                var operation = (IMethodReferenceOperation)context.Operation;
+                if (IsOptionOfTNoneMethodGroup(operation, optionOfTType))
+                {
+                    var itemType = operation.Method.ContainingType.TypeArguments.Single();
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, operation.Syntax.GetLocation(), itemType.ToDisplayString()));
+                }
+            };
+
+    private static bool IsOptionOfTNoneMethodGroup(IMethodReferenceOperation operation, INamedTypeSymbol genericOptionType)
+        => operation.Method.Name is WellKnownMemberNames.OptionOfT.None
+           && SymbolEqualityComparer.Default.Equals(genericOptionType, operation.Method.ContainingType.ConstructedFrom);
+}

--- a/Funcky.Analyzers/Funcky.BuiltinAnalyzers/OptionNoneMethodGroupFix.cs
+++ b/Funcky.Analyzers/Funcky.BuiltinAnalyzers/OptionNoneMethodGroupFix.cs
@@ -1,0 +1,68 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Simplification;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Funcky.BuiltinAnalyzers;
+
+[Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(OptionNoneCodeFix))]
+public sealed class OptionNoneCodeFix : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds
+        => ImmutableArray.Create(OptionNoneMethodGroupAnalyzer.Descriptor.Id);
+
+    public override FixAllProvider GetFixAllProvider()
+        => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        if (await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false) is { } root
+            && await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false) is { } semanticModel
+            && semanticModel.Compilation.GetOptionType() is { } optionType)
+        {
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                if (root.FindNode(diagnostic.Location.SourceSpan).FirstAncestorOrSelf<ExpressionSyntax>(node => semanticModel.GetOperation(node) is IMethodReferenceOperation) is { } syntax
+                    && semanticModel.GetOperation(syntax) is IMethodReferenceOperation methodReference)
+                {
+                    context.RegisterCodeFix(CreateFix(context, methodReference, optionType), diagnostic);
+                }
+            }
+        }
+    }
+
+    private static CodeAction CreateFix(CodeFixContext context, IMethodReferenceOperation methodReference, INamedTypeSymbol optionType)
+        => CodeAction.Create(
+            "Use Option.None<T>",
+            AddArgumentLabelAsync(context.Document, methodReference, optionType),
+            nameof(OptionNoneCodeFix));
+
+    private static Func<CancellationToken, Task<Document>> AddArgumentLabelAsync(Document document, IMethodReferenceOperation methodReference, INamedTypeSymbol optionType)
+        => async cancellationToken
+            =>
+            {
+                var editor = await DocumentEditor.CreateAsync(document, cancellationToken);
+                editor.ReplaceNode(methodReference.Syntax, GenerateOptionNoneMemberAccess(editor.Generator, methodReference, optionType));
+                return editor.GetChangedDocument();
+            };
+
+    private static SyntaxNode GenerateOptionNoneMemberAccess(SyntaxGenerator generator, IMethodReferenceOperation methodReference, INamedTypeSymbol optionType)
+    {
+        var itemType = methodReference.Method.ContainingType.TypeArguments.Single();
+        return MemberAccessExpression(
+            SyntaxKind.SimpleMemberAccessExpression,
+            (TypeSyntax)generator.TypeExpression(optionType),
+            GenericName(
+                Identifier(WellKnownMemberNames.Option.None),
+                TypeArgumentList(SingletonSeparatedList((TypeSyntax)generator.TypeExpression(itemType)))))
+            .WithAdditionalAnnotations(Simplifier.Annotation);
+    }
+}

--- a/Funcky.Analyzers/Funcky.BuiltinAnalyzers/TryGetValueAnalyzer.cs
+++ b/Funcky.Analyzers/Funcky.BuiltinAnalyzers/TryGetValueAnalyzer.cs
@@ -9,7 +9,7 @@ namespace Funcky.BuiltinAnalyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class TryGetValueAnalyzer : DiagnosticAnalyzer
 {
-    private static readonly DiagnosticDescriptor Descriptor = new(
+    private static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
         id: "λ0001",
         title: "Disallowed use of TryGetValue",
         messageFormat: "Disallowed use of TryGetValue",

--- a/Funcky.Analyzers/Funcky.BuiltinAnalyzers/WellKnownMemberNames.cs
+++ b/Funcky.Analyzers/Funcky.BuiltinAnalyzers/WellKnownMemberNames.cs
@@ -5,5 +5,11 @@ internal static class WellKnownMemberNames
     public static class OptionOfT
     {
         public const string TryGetValue = "TryGetValue";
+        public const string None = "None";
+    }
+
+    public static class Option
+    {
+        public const string None = "None";
     }
 }

--- a/Funcky/DataTypes/EitherOrBoth.cs
+++ b/Funcky/DataTypes/EitherOrBoth.cs
@@ -134,7 +134,7 @@ namespace Funcky.DataTypes
                 left: Left<TLeft, TRight>,
                 right: Right<TLeft, TRight>,
                 leftAndRight: Both,
-                none: Option<EitherOrBoth<TLeft, TRight>>.None);
+                none: Option.None<EitherOrBoth<TLeft, TRight>>);
 
         private static Option<EitherOrBoth<TLeft, TRight>> Left<TLeft, TRight>(TLeft left)
             where TLeft : notnull

--- a/Funcky/Monads/Option/Option.Core.cs
+++ b/Funcky/Monads/Option/Option.Core.cs
@@ -23,6 +23,7 @@ namespace Funcky.Monads
             _hasItem = true;
         }
 
+        /// <summary>Returns an empty option.</summary>
         [Pure]
         public static Option<TItem> None() => default;
 
@@ -106,5 +107,12 @@ namespace Funcky.Monads
         public static Option<TItem> Return<TItem>(TItem item)
             where TItem : notnull
             => new(item);
+
+        /// <summary>Returns an empty option.</summary>
+        /// <remarks>This method is intended to be used as a method-group. Use <see cref="Option{TItem}.None"/> in all other cases.</remarks>
+        [Pure]
+        public static Option<TItem> None<TItem>()
+            where TItem : notnull
+            => default;
     }
 }

--- a/Funcky/Monads/Option/Option.Monad.cs
+++ b/Funcky/Monads/Option/Option.Monad.cs
@@ -6,14 +6,14 @@ namespace Funcky.Monads
         public Option<TResult> Select<TResult>(Func<TItem, TResult> selector)
             where TResult : notnull
             => Match(
-                 none: Option<TResult>.None,
+                 none: Option.None<TResult>,
                  some: item => selector(item));
 
         [Pure]
         public Option<TResult> SelectMany<TResult>(Func<TItem, Option<TResult>> selector)
             where TResult : notnull
             => Match(
-                 none: Option<TResult>.None,
+                 none: Option.None<TResult>,
                  some: selector);
 
         [Pure]

--- a/Funcky/PublicAPI.Unshipped.txt
+++ b/Funcky/PublicAPI.Unshipped.txt
@@ -172,6 +172,7 @@ static Funcky.Extensions.ParseExtensions.ParseVersionOrNone(this string? candida
 static Funcky.Extensions.ParseExtensions.ParseViaHeaderValueOrNone(this string? candidate) -> Funcky.Monads.Option<System.Net.Http.Headers.ViaHeaderValue!>
 static Funcky.Extensions.ParseExtensions.ParseWarningHeaderValueOrNone(this string? candidate) -> Funcky.Monads.Option<System.Net.Http.Headers.WarningHeaderValue!>
 static Funcky.Monads.Either<TLeft, TRight>.implicit operator Funcky.Monads.Either<TLeft, TRight>(TRight right) -> Funcky.Monads.Either<TLeft, TRight>
+static Funcky.Monads.Option.None<TItem>() -> Funcky.Monads.Option<TItem>
 static Funcky.Monads.OptionExtensions.ToEither<TLeft, TRight>(this Funcky.Monads.Option<TRight> option, System.Func<TLeft>! getLeft) -> Funcky.Monads.Either<TLeft, TRight>
 static Funcky.Monads.OptionExtensions.ToEither<TLeft, TRight>(this Funcky.Monads.Option<TRight> option, TLeft left) -> Funcky.Monads.Either<TLeft, TRight>
 static Funcky.Monads.Result<TValidResult>.implicit operator Funcky.Monads.Result<TValidResult>(TValidResult item) -> Funcky.Monads.Result<TValidResult>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "6.0.202",
     "rollForward": "feature"
   },
   "msbuild-sdks": {


### PR DESCRIPTION
We added this method in `funcky3` for use as method group.

This is something we should add to Funcky 2.x too. This allows people to fix this already, so they have fewer things to fix when they update to Funcky 3.