### PR TITLE
New interface `IBuffer<T>` and `Memoize` extension on `IEnumerable<T>`

### DIFF
--- a/Funcky.Test/Extensions/EnumerableExtensions/MemoizeTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/MemoizeTest.cs
@@ -1,0 +1,69 @@
+using Funcky.Test.TestUtils;
+
+namespace Funcky.Test
+{
+    public sealed class MemoizeTest
+    {
+        [Fact]
+        public void MemoizeIsEnumeratedLazily()
+        {
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
+
+            using var memoized = doNotEnumerate.Memoize();
+        }
+
+        [Fact]
+        public void TheUnderlyingEnumerableIsOnlyEnumeratedOnce()
+        {
+            var enumerateOnce = new EnumerateOnce<string>(Sequence.Return("Alpha", "Beta"));
+            using var memoized = enumerateOnce.Memoize();
+
+            Assert.Equal("Alpha", memoized.First());
+            Assert.Equal("Alpha", memoized.First());
+
+            Assert.Equal("Beta", memoized.Last());
+            Assert.Equal("Beta", memoized.Last());
+        }
+
+        [Fact]
+        public void MemoizingAnEmptyListIsEmpty()
+        {
+            var empty = Enumerable.Empty<string>();
+            using var memoized = empty.Memoize();
+
+            Assert.Empty(memoized);
+        }
+
+        [Fact]
+        public void OutOfOrderMoveNextReturnsItemsInTheRightOrder()
+        {
+            using var memoizedRange = Enumerable.Range(1, 10).Memoize();
+
+            using var enumerator1 = memoizedRange.GetEnumerator();
+
+            Assert.True(enumerator1.MoveNext());
+            Assert.True(enumerator1.MoveNext());
+
+            Assert.Equal(2, enumerator1.Current);
+
+            using var enumerator2 = memoizedRange.GetEnumerator();
+
+            Assert.True(enumerator2.MoveNext());
+            Assert.Equal(1, enumerator2.Current);
+
+            Assert.True(enumerator1.MoveNext());
+            Assert.True(enumerator1.MoveNext());
+
+            Assert.Equal(4, enumerator1.Current);
+
+            Assert.True(enumerator2.MoveNext());
+            Assert.Equal(2, enumerator2.Current);
+            Assert.True(enumerator2.MoveNext());
+            Assert.Equal(3, enumerator2.Current);
+            Assert.True(enumerator2.MoveNext());
+            Assert.Equal(4, enumerator2.Current);
+            Assert.True(enumerator2.MoveNext());
+            Assert.Equal(5, enumerator2.Current);
+        }
+    }
+}

--- a/Funcky.Test/Sequence/CycleRangeTest.cs
+++ b/Funcky.Test/Sequence/CycleRangeTest.cs
@@ -8,30 +8,57 @@ namespace Funcky.Test
     public sealed class CycleRangeTest
     {
         [Fact]
+        public void CycleRangeIsEnumeratedLazily()
+        {
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
+
+            using var cycleRange = Sequence.CycleRange(doNotEnumerate);
+        }
+
+        [Fact]
         public void CyclingAnEmptySetThrowsAnArgumentException()
-            => Assert.Throws<ArgumentException>(() => Sequence.CycleRange(ImmutableList<string>.Empty));
+            => Assert.Throws<InvalidOperationException>(CycleEmptySequence);
 
         [Property]
         public Property CycleRangeCanProduceArbitraryManyItems(NonEmptySet<int> sequence, PositiveInt arbitraryElements)
-            => (Sequence.CycleRange(sequence.Get).Take(arbitraryElements.Get).Count() == arbitraryElements.Get)
+        {
+            using var cycleRange = Sequence
+                .CycleRange(sequence.Get);
+
+            return (cycleRange.Take(arbitraryElements.Get).Count() == arbitraryElements.Get)
                 .ToProperty();
+        }
 
         [Property]
         public Property CycleRangeRepeatsTheElementsArbitraryManyTimes(NonEmptySet<int> sequence, PositiveInt arbitraryElements)
-            => Sequence
-                .CycleRange(sequence.Get)
+        {
+            using var cycleRange = Sequence
+                .CycleRange(sequence.Get);
+
+            return cycleRange
                 .IsSequenceRepeating(sequence.Get)
                 .NTimes(arbitraryElements.Get);
+        }
 
         [Property]
         public void CycleRangeEnumeratesUnderlyingEnumerableOnlyOnce(NonEmptySet<int> sequence)
         {
             var enumerateOnce = new EnumerateOnce<int>(sequence.Get);
 
-            Sequence
-                .CycleRange(enumerateOnce)
+            using var cycleRange = Sequence
+                .CycleRange(enumerateOnce);
+
+            cycleRange
                 .Take(sequence.Get.Count * 3)
                 .ForEach(NoOperation);
+        }
+
+        private static void CycleEmptySequence()
+        {
+            using var cycledRange = Sequence.CycleRange(ImmutableList<string>.Empty);
+            using var enumerator = cycledRange.GetEnumerator();
+
+            enumerator.MoveNext();
         }
     }
 }

--- a/Funcky.Test/Sequence/RepeatRangeTest.cs
+++ b/Funcky.Test/Sequence/RepeatRangeTest.cs
@@ -6,31 +6,41 @@ namespace Funcky.Test
 {
     public sealed class RepeatRangeTest
     {
-        [Property]
+        [Fact]
+        public void RepeatRangeIsEnumeratedLazily()
+        {
+            var doNotEnumerate = new FailOnEnumerationSequence<object>();
+
+            using var repeatRange = Sequence.RepeatRange(doNotEnumerate, 2);
+        }
+
         public Property TheLengthOfTheGeneratedRepeatRangeIsCorrect(List<int> list, NonNegativeInt count)
         {
-            var sequence = Sequence
-                .RepeatRange(list, count.Get)
-                .ToList();
+            using var repeatRange = Sequence.RepeatRange(list, count.Get);
 
-            return (sequence.Count == list.Count * count.Get).ToProperty();
+            var materialized = repeatRange.ToList();
+
+            return (materialized.Count == list.Count * count.Get).ToProperty();
         }
 
         [Property]
         public Property TheSequenceRepeatsTheGivenNumberOfTimes(List<int> list, NonNegativeInt count)
-            => Sequence
-                .RepeatRange(list, count.Get)
+        {
+            using var repeatRange = Sequence.RepeatRange(list, count.Get);
+
+            return repeatRange
                 .IsSequenceRepeating(list)
                 .NTimes(count.Get);
+        }
 
         [Property]
         public void RepeatRangeEnumeratesUnderlyingEnumerableOnlyOnce(NonEmptySet<int> sequence)
         {
             var enumerateOnce = new EnumerateOnce<int>(sequence.Get);
 
-            Sequence
-                .RepeatRange(enumerateOnce, 3)
-                .ForEach(NoOperation);
+            using var repeatRange = Sequence.RepeatRange(enumerateOnce, 3);
+
+            repeatRange.ForEach(NoOperation);
         }
     }
 }

--- a/Funcky.Test/TestUtils/FailOnEnumerationSequence.cs
+++ b/Funcky.Test/TestUtils/FailOnEnumerationSequence.cs
@@ -6,7 +6,13 @@ namespace Funcky.Test.TestUtils
     internal sealed class FailOnEnumerationSequence<T> : IEnumerable<T>
     {
         public IEnumerator<T> GetEnumerator()
-            => throw new XunitException("Sequence was unexpectedly enumerated.");
+        {
+            throw new XunitException("Sequence was unexpectedly enumerated.");
+
+#pragma warning disable CS0162 // Unreachable code detected
+            yield break; // this forces the method emit the statemachine even though it is not reachable!
+#pragma warning restore CS0162 // Unreachable code detected
+        }
 
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();

--- a/Funcky/Extensions/EnumerableExtensions/Memoize.cs
+++ b/Funcky/Extensions/EnumerableExtensions/Memoize.cs
@@ -1,0 +1,81 @@
+using System.Collections;
+
+namespace Funcky.Extensions
+{
+    public static partial class EnumerableExtensions
+    {
+        /// <summary>
+        /// Creates a buffer with a view over the source sequence, causing each enumerator to obtain access to all of the
+        /// sequence's elements without causing multiple enumerations over the source.
+        /// </summary>
+        /// <typeparam name="TSource">Type of the elements in <paramref name="sequence"/> sequence.</typeparam>
+        /// <param name="sequence">The source sequence.</param>
+        /// <returns>A lazy buffer of the underlying sequence.</returns>
+        [Pure]
+        public static IBuffer<TSource> Memoize<TSource>(this IEnumerable<TSource> sequence)
+            where TSource : notnull
+            => sequence is IBuffer<TSource> buffer
+                ? buffer
+                : MemoizedBuffer.Create(sequence);
+
+        private static class MemoizedBuffer
+        {
+            public static MemoizedBuffer<TSource> Create<TSource>(IEnumerable<TSource> source)
+                => new(source);
+        }
+
+        private sealed class MemoizedBuffer<T> : IBuffer<T>
+        {
+            private readonly List<T> _buffer = new();
+            private readonly IEnumerator<T> _source;
+
+            private bool _disposed;
+
+            public MemoizedBuffer(IEnumerable<T> source)
+                => _source = source.GetEnumerator();
+
+            public IEnumerator<T> GetEnumerator()
+                => _disposed
+                ? throw new ObjectDisposedException("Buffer already disposed.")
+                : GetEnumeratorInternal();
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            public void Dispose()
+            {
+                if (!_disposed)
+                {
+                    _source.Dispose();
+                    _buffer.Clear();
+                }
+
+                _disposed = true;
+            }
+
+            private IEnumerator<T> GetEnumeratorInternal()
+            {
+                var index = 0;
+
+                while (true)
+                {
+                    if (index == _buffer.Count)
+                    {
+                        if (_source.MoveNext())
+                        {
+                            _buffer.Add(_source.Current);
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+
+                    yield return _buffer[index++];
+                }
+            }
+        }
+    }
+}

--- a/Funcky/Extensions/EnumerableExtensions/Memoize.cs
+++ b/Funcky/Extensions/EnumerableExtensions/Memoize.cs
@@ -61,6 +61,11 @@ namespace Funcky.Extensions
 
                 while (true)
                 {
+                    if (_disposed)
+                    {
+                        throw new ObjectDisposedException("Buffer already disposed.");
+                    }
+
                     if (index == _buffer.Count)
                     {
                         if (_source.MoveNext())

--- a/Funcky/IBuffer.cs
+++ b/Funcky/IBuffer.cs
@@ -1,0 +1,10 @@
+namespace Funcky
+{
+    /// <summary>
+    /// Represents a buffer of an underlying <see cref="IEnumerable{TItem}"/> resource and is <see cref="IDisposable"/> accordingly.
+    /// </summary>
+    /// <typeparam name="TSource">Element type.</typeparam>
+    public interface IBuffer<out TSource> : IEnumerable<TSource>, IDisposable
+    {
+    }
+}

--- a/Funcky/PublicAPI.Shipped.txt
+++ b/Funcky/PublicAPI.Shipped.txt
@@ -373,12 +373,10 @@ static Funcky.Monads.Result<TValidResult>.operator ==(Funcky.Monads.Result<TVali
 static Funcky.Sequence.Concat<TSource>(params System.Collections.Generic.IEnumerable<TSource>![]! sources) -> System.Collections.Generic.IEnumerable<TSource>!
 static Funcky.Sequence.Concat<TSource>(System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<TSource>!>! sources) -> System.Collections.Generic.IEnumerable<TSource>!
 static Funcky.Sequence.Cycle<TItem>(TItem element) -> System.Collections.Generic.IEnumerable<TItem>!
-static Funcky.Sequence.CycleRange<TItem>(System.Collections.Generic.IEnumerable<TItem>! sequence) -> System.Collections.Generic.IEnumerable<TItem>!
 static Funcky.Sequence.FromNullable<T>(T? item) -> System.Collections.Generic.IEnumerable<T!>!
 static Funcky.Sequence.FromNullable<T>(T? item) -> System.Collections.Generic.IEnumerable<T>!
 static Funcky.Sequence.Generate<TItem>(TItem seed, System.Func<TItem, Funcky.Monads.Option<TItem>>! next) -> System.Collections.Generic.IEnumerable<TItem>!
 static Funcky.Sequence.Generate<TItem>(TItem seed, System.Func<TItem, TItem>! next) -> System.Collections.Generic.IEnumerable<TItem>!
-static Funcky.Sequence.RepeatRange<TItem>(System.Collections.Generic.IEnumerable<TItem>! sequence, int count) -> System.Collections.Generic.IEnumerable<TItem>!
 static Funcky.Sequence.Successors<TItem>(Funcky.Monads.Option<TItem> first, System.Func<TItem, Funcky.Monads.Option<TItem>>! successor) -> System.Collections.Generic.IEnumerable<TItem>!
 static Funcky.Sequence.Successors<TItem>(Funcky.Monads.Option<TItem> first, System.Func<TItem, TItem>! successor) -> System.Collections.Generic.IEnumerable<TItem>!
 static Funcky.Sequence.Successors<TItem>(TItem first, System.Func<TItem, Funcky.Monads.Option<TItem>>! successor) -> System.Collections.Generic.IEnumerable<TItem>!

--- a/Funcky/PublicAPI.Unshipped.txt
+++ b/Funcky/PublicAPI.Unshipped.txt
@@ -5,6 +5,7 @@ Funcky.EitherOrBoth<TLeft, TRight>.Equals(Funcky.EitherOrBoth<TLeft, TRight> oth
 Funcky.EitherOrBoth<TLeft, TRight>.Match<TMatchResult>(System.Func<TLeft, TMatchResult>! left, System.Func<TRight, TMatchResult>! right, System.Func<TLeft, TRight, TMatchResult>! both) -> TMatchResult
 Funcky.EitherOrBoth<TLeft, TRight>.Switch(System.Action<TLeft>! left, System.Action<TRight>! right, System.Action<TLeft, TRight>! both) -> void
 Funcky.Extensions.ActionExtensions
+Funcky.IBuffer<TSource>
 Funcky.Monads.Either<TLeft, TRight>.Flip() -> Funcky.Monads.Either<TRight, TLeft>
 Funcky.Monads.Either<TLeft, TRight>.SelectMany<TEither, TResult>(System.Func<TRight, Funcky.Monads.Either<TLeft, TEither>>! selector, System.Func<TRight, TEither, TResult>! resultSelector) -> Funcky.Monads.Either<TLeft, TResult>
 Funcky.Monads.Either<TLeft, TRight>.Switch(System.Action<TLeft>! left, System.Action<TRight>! right) -> void
@@ -70,6 +71,7 @@ static Funcky.Extensions.EnumerableExtensions.Chunk<TSource>(System.Collections.
 static Funcky.Extensions.EnumerableExtensions.ForEach<T>(this System.Collections.Generic.IEnumerable<T>! elements, System.Action<T>! action) -> Funcky.Unit
 static Funcky.Extensions.EnumerableExtensions.Materialize<TItem, TMaterialization>(this System.Collections.Generic.IEnumerable<TItem>! source, System.Func<System.Collections.Generic.IEnumerable<TItem>!, TMaterialization>! materialize) -> System.Collections.Generic.IReadOnlyCollection<TItem>!
 static Funcky.Extensions.EnumerableExtensions.Materialize<TItem>(this System.Collections.Generic.IEnumerable<TItem>! source) -> System.Collections.Generic.IReadOnlyCollection<TItem>!
+static Funcky.Extensions.EnumerableExtensions.Memoize<TSource>(this System.Collections.Generic.IEnumerable<TSource>! sequence) -> Funcky.IBuffer<TSource>!
 static Funcky.Extensions.EnumerableExtensions.Partition<TItem, TResult>(this System.Collections.Generic.IEnumerable<TItem>! source, System.Func<TItem, bool>! predicate, System.Func<System.Collections.Generic.IReadOnlyList<TItem>!, System.Collections.Generic.IReadOnlyList<TItem>!, TResult>! resultSelector) -> TResult
 static Funcky.Extensions.EnumerableExtensions.Partition<TItem>(this System.Collections.Generic.IEnumerable<TItem>! source, System.Func<TItem, bool>! predicate) -> (System.Collections.Generic.IReadOnlyList<TItem>! True, System.Collections.Generic.IReadOnlyList<TItem>! False)
 static Funcky.Extensions.EnumerableExtensions.Shuffle<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source) -> System.Collections.Generic.IReadOnlyList<TSource>!
@@ -94,5 +96,7 @@ static Funcky.Functional.True<T1, T2>(T1 ω1, T2 ω2) -> bool
 static Funcky.Functional.True<T1>(T1 ω1) -> bool
 static Funcky.Monads.Option<TItem>.None.get -> Funcky.Monads.Option<TItem>
 static Funcky.Monads.Result<TValidResult>.Error(System.Exception! exception) -> Funcky.Monads.Result<TValidResult>
+static Funcky.Sequence.CycleRange<TItem>(System.Collections.Generic.IEnumerable<TItem>! sequence) -> Funcky.IBuffer<TItem>!
+static Funcky.Sequence.RepeatRange<TItem>(System.Collections.Generic.IEnumerable<TItem>! sequence, int count) -> Funcky.IBuffer<TItem>!
 static Funcky.Sequence.Return<TItem>(TItem item) -> System.Collections.Generic.IReadOnlyList<TItem>!
 static Funcky.Sequence.Return<TItem>(params TItem[]! items) -> System.Collections.Generic.IReadOnlyList<TItem>!

--- a/Funcky/Sequence/Sequence.CycleRange.cs
+++ b/Funcky/Sequence/Sequence.CycleRange.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+using System.Collections;
 
 namespace Funcky
 {
@@ -11,22 +11,100 @@ namespace Funcky
         /// <param name="sequence">The sequence of elements which are cycled. Throws an exception if the sequence is empty.</param>
         /// <returns>Returns an infinite IEnumerable repeating the same sequence of elements.</returns>
         [Pure]
-        public static IEnumerable<TItem> CycleRange<TItem>(IEnumerable<TItem> sequence)
+        public static IBuffer<TItem> CycleRange<TItem>(IEnumerable<TItem> sequence)
             where TItem : notnull
-            => CycleSequenceIfNotEmpty(sequence.Materialize());
+            => CycleBuffer.Create(sequence);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static IEnumerable<TItem> CycleSequenceIfNotEmpty<TItem>(IReadOnlyCollection<TItem> sequence)
-            where TItem : notnull
-            => sequence.Count != 0
-                ? ProjectCycles(sequence)
-                : throw new ArgumentException("An empty sequence cannot be cycled", nameof(sequence));
+        private static class CycleBuffer
+        {
+            public static CycleBuffer<TSource> Create<TSource>(IEnumerable<TSource> source, Option<int> maxCycles = default)
+                => new(source, maxCycles);
+        }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static IEnumerable<TItem> ProjectCycles<TItem>(IReadOnlyCollection<TItem> list)
-            where TItem : notnull
-            => from cycle in Cycle(list)
-               from element in cycle
-               select element;
+        private sealed class CycleBuffer<T> : IBuffer<T>
+        {
+            private readonly List<T> _buffer = new();
+            private readonly IEnumerator<T> _source;
+            private readonly Option<int> _maxCycles;
+
+            private bool _disposed;
+
+            public CycleBuffer(IEnumerable<T> source, Option<int> maxCycles = default)
+            {
+                _source = source.GetEnumerator();
+                _maxCycles = maxCycles;
+            }
+
+            public void Dispose()
+            {
+                if (!_disposed)
+                {
+                    _source.Dispose();
+                    _buffer.Clear();
+                }
+
+                _disposed = true;
+            }
+
+            public IEnumerator<T> GetEnumerator()
+                => _disposed
+                ? throw new ObjectDisposedException("Buffer already disposed.")
+                : GetEnumeratorInternal();
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            private IEnumerator<T> GetEnumeratorInternal()
+            {
+                if (_maxCycles.Match(none: false, some: maxCycles => maxCycles is 0))
+                {
+                    yield break;
+                }
+
+                var index = 0;
+
+                while (true)
+                {
+                    if (index == _buffer.Count)
+                    {
+                        if (_source.MoveNext())
+                        {
+                            _buffer.Add(_source.Current);
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+
+                    yield return _buffer[index++];
+                }
+
+                if (_buffer.Count is 0)
+                {
+                    if (_maxCycles.Match(none: true, some: False))
+                    {
+                        throw new InvalidOperationException("you cannot cycle an empty enumerable");
+                    }
+                    else
+                    {
+                        yield break;
+                    }
+                }
+
+                for (int cycle = 1; IsCycling(cycle); ++cycle)
+                {
+                    foreach (var value in _buffer)
+                    {
+                        yield return value;
+                    }
+                }
+            }
+
+            private bool IsCycling(int cycle)
+                => _maxCycles.Match(none: true, maxCycles => maxCycles < cycle);
+        }
     }
 }

--- a/Funcky/Sequence/Sequence.RepeatRange.cs
+++ b/Funcky/Sequence/Sequence.RepeatRange.cs
@@ -10,14 +10,8 @@ namespace Funcky
         /// <param name="count">The number of times to repeat the value in the generated sequence.</param>
         /// <returns>Returns an infinite IEnumerable cycling through the same elements.</returns>
         [Pure]
-        public static IEnumerable<TItem> RepeatRange<TItem>(IEnumerable<TItem> sequence, int count)
+        public static IBuffer<TItem> RepeatRange<TItem>(IEnumerable<TItem> sequence, int count)
             where TItem : notnull
-            => RepeatCollection(sequence.Materialize(), count);
-
-        private static IEnumerable<TItem> RepeatCollection<TItem>(IReadOnlyCollection<TItem> collection, int count)
-            where TItem : notnull
-            => Enumerable
-                .Repeat(Unit.Value, count)
-                .SelectMany(_ => collection);
+            => CycleBuffer.Create(sequence, count);
     }
 }


### PR DESCRIPTION
* `IBuffer<T>` is an Interface combining `IEnumerable<T>` and `IDisposable`
* `CycleRange` and `RepeatRange` now return `IBuffer<T>`
* `CycleRange` and `RepeatRange` are now lazy