### PR TITLE
Reference Funcky using a semantic version range in Funcky.Xunit

### DIFF
--- a/Funcky.Async/Funcky.Async.csproj
+++ b/Funcky.Async/Funcky.Async.csproj
@@ -5,7 +5,7 @@
         <Nullable>enable</Nullable>
         <Description>Extends Funcky with support for IAsyncEnumerable and Tasks.</Description>
         <PackageTags>Functional Async Monad Linq</PackageTags>
-        <Version>1.4.0</Version>
+        <VersionPrefix>1.4.0</VersionPrefix>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>

--- a/Funcky.Async/Funcky.Async.csproj
+++ b/Funcky.Async/Funcky.Async.csproj
@@ -51,4 +51,5 @@
     <Import Project="..\Analyzers.props" />
     <Import Project="..\GlobalUsings.props" />
     <Import Project="..\FrameworkFeatureConstants.props" />
+    <Import Project="..\SemanticVersioning.targets" />
 </Project>

--- a/Funcky.Xunit/Funcky.Xunit.csproj
+++ b/Funcky.Xunit/Funcky.Xunit.csproj
@@ -5,7 +5,7 @@
         <Nullable>enable</Nullable>
         <Description>Package to use Funcky with xUnit</Description>
         <PackageTags>Functional Monad xUnit</PackageTags>
-        <Version>2.1.0</Version>
+        <VersionPrefix>2.1.0</VersionPrefix>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <RootNamespace>Funcky</RootNamespace>

--- a/Funcky.Xunit/Funcky.Xunit.csproj
+++ b/Funcky.Xunit/Funcky.Xunit.csproj
@@ -28,4 +28,5 @@
     </ItemGroup>
     <Import Project="..\Analyzers.props" />
     <Import Project="..\GlobalUsings.props" />
+    <Import Project="..\SemanticVersioning.targets" />
 </Project>

--- a/Funcky.sln
+++ b/Funcky.sln
@@ -26,6 +26,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build Config", "Build Confi
 		NuGet.config = NuGet.config
 		typos.toml = typos.toml
 		Analyzers.props = Analyzers.props
+		SemanticVersioning.targets = SemanticVersioning.targets
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Funcky.Xunit", "Funcky.Xunit\Funcky.Xunit.csproj", "{F2E98B0D-CC17-4576-89DE-065FF475BE6E}"

--- a/SemanticVersioning.targets
+++ b/SemanticVersioning.targets
@@ -1,13 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
+	<PropertyGroup>
+		<!-- We are loaded *before* NuGet.Build.Tasks.Pack.targets, so we can't use the $(NuGetPackTaskAssemblyFile) and $(NuGetBuildTasksPackTargets) properties.
+		     Thus we re-define some of the things here based on $(MSBuildToolsPath). Let's hope it doesn't break. -->
+		<_NuGetVersioningAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildToolsPath)/Sdks/NuGet.Build.Tasks.Pack/CoreCLR/NuGet.Versioning.dll</_NuGetVersioningAssemblyFile>
+		<_NuGetVersioningAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildToolsPath)/Sdks/NuGet.Build.Tasks.Pack/Desktop/NuGet.Versioning.dll</_NuGetVersioningAssemblyFile>
+		<_NuGetVersioningAssemblyFile Condition="!$([System.IO.Path]::Exists('$(_NuGetVersioningAssemblyFile)'))">$(MSBuildToolsPath)/NuGet.Versioning.dll</_NuGetVersioningAssemblyFile>
+	</PropertyGroup>
 	<UsingTask TaskName="GenerateSemanticVersionRanges" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
 		<ParameterGroup>
 			<ProjectReferencesWithVersions ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
 			<ProjectReferencesWithExactVersions ParameterType="Microsoft.Build.Framework.ITaskItem[]" Output="true" />
 		</ParameterGroup>
 		<Task>
-			<!-- $(NuGetPackTaskAssemblyFile) is a path relative to the $(NuGetBuildTasksPackTargets) file. -->
-			<Reference Include="$([System.IO.Path]::GetDirectoryName($([System.IO.Path]::Combine($([System.IO.Path]::GetDirectoryName($(NuGetBuildTasksPackTargets))), $(NuGetPackTaskAssemblyFile)))))/NuGet.Versioning.dll" />
+			<Reference Include="$(_NuGetVersioningAssemblyFile)" />
 			<Using Namespace="NuGet.Versioning" />
 			<!-- language=C# -->
 			<Code Type="Fragment" Language="cs"><![CDATA[

--- a/SemanticVersioning.targets
+++ b/SemanticVersioning.targets
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<UsingTask TaskName="GenerateSemanticVersionRanges" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+		<ParameterGroup>
+			<ProjectReferencesWithVersions ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+			<ProjectReferencesWithExactVersions ParameterType="Microsoft.Build.Framework.ITaskItem[]" Output="true" />
+		</ParameterGroup>
+		<Task>
+			<!-- $(NuGetPackTaskAssemblyFile) is a path relative to the $(NuGetBuildTasksPackTargets) file. -->
+			<Reference Include="$([System.IO.Path]::GetDirectoryName($([System.IO.Path]::Combine($([System.IO.Path]::GetDirectoryName($(NuGetBuildTasksPackTargets))), $(NuGetPackTaskAssemblyFile)))))/NuGet.Versioning.dll" />
+			<Using Namespace="NuGet.Versioning" />
+			<!-- language=C# -->
+			<Code Type="Fragment" Language="cs"><![CDATA[
+				foreach (var projectReference in ProjectReferencesWithVersions)
+				{
+					var versionString = projectReference.GetMetadata("ProjectVersion");
+					if (!SemanticVersion.TryParse(versionString, out var version)) {
+						Log.LogError("'{0}' is not a valid semantic version", versionString);
+						return false;
+					}
+
+					var range = version switch
+					{
+                        // No SemVer guarantees for pre-release (e.g. nightly) versions, so we use an exact version.
+						{ IsPrerelease: true } => $"[{version}]",
+						// We use Cargo's convention for 0.x versions i.e. minor = breaking, patch = feature or patch.
+						{ Major: 0, Minor: var minor, Patch: var patch } => $"[0.{minor}.{patch}, 0.{minor + 1})",
+						// 1.x versions follow regular SemVer rules.
+						{ Major: var major, Minor: var minor, Patch: var patch } => $"[{major}.{minor}.{patch}, {major + 1})",
+					};
+					projectReference.SetMetadata("ProjectVersion", range);
+				}
+
+				ProjectReferencesWithExactVersions = ProjectReferencesWithVersions;
+			]]></Code>
+		</Task>
+	</UsingTask>
+	<!-- This workaround is based on comments in: https://github.com/NuGet/Home/issues/5556#issuecomment-753526765 -->
+	<Target Name="_ExactProjectReferencesVersion" AfterTargets="_GetProjectReferenceVersions">
+		<GenerateSemanticVersionRanges ProjectReferencesWithVersions="@(_ProjectReferencesWithVersions)">
+			<Output ItemName="_ProjectReferencesWithExactVersions" TaskParameter="ProjectReferencesWithExactVersions" />
+		</GenerateSemanticVersionRanges>
+		<ItemGroup>
+			<_ProjectReferencesWithVersions Remove="@(_ProjectReferencesWithVersions)" />
+			<_ProjectReferencesWithVersions Include="@(_ProjectReferencesWithExactVersions)" />
+		</ItemGroup>
+	</Target>
+</Project>


### PR DESCRIPTION
With this change Funcky.Xunit and Funcky.Async depend on Funcky using a semantic version range i.e. `[3.5.0, 4)`.