### PR TITLE
Unify the monad law tests for all the 5 monads we support

### DIFF
--- a/Funcky.FsCheck/FunckyGenerators.fs
+++ b/Funcky.FsCheck/FunckyGenerators.fs
@@ -51,13 +51,9 @@ type FunckyGenerators =
 #endif
 
     static member nonNull<'a>() =
-        let notNull x = not (Object.ReferenceEquals(x, null))
-        { new Arbitrary<NonNull<'a>>() with
-            override _.Generator =
-                Arb.generate |> Gen.where notNull |> Gen.map NonNull
-            override _.Shrinker (NonNull o) =
-                Arb.shrink o |> Seq.where notNull |> Seq.map NonNull
-        }
+        Arb.from<'a>
+            |> Arb.filter (fun x -> not (Object.ReferenceEquals(x, null)))
+            |> Arb.convert NonNull (fun x -> x.Get)
 
     static member option<'a>() =
         { new Arbitrary<Funcky.Monads.Option<'a>>() with

--- a/Funcky.FsCheck/FunckyGenerators.fs
+++ b/Funcky.FsCheck/FunckyGenerators.fs
@@ -21,6 +21,9 @@ type EquatableException =
 
     override this.GetHashCode() = this.Message.GetHashCode()
 
+type NonNull<'a> = NonNull of 'a with
+    member x.Get = match x with NonNull r -> r
+
 [<Sealed>]
 [<AbstractClass>]
 type FunckyGenerators =
@@ -47,22 +50,28 @@ type FunckyGenerators =
                    return PriorityQueue(values) }
 #endif
 
+    static member nonNull<'a>() =
+        let notNull x = not (Object.ReferenceEquals(x, null))
+        { new Arbitrary<NonNull<'a>>() with
+            override _.Generator =
+                Arb.generate |> Gen.where notNull |> Gen.map NonNull
+            override _.Shrinker (NonNull o) =
+                Arb.shrink o |> Seq.where notNull |> Seq.map NonNull
+        }
+
     static member option<'a>() =
         { new Arbitrary<Funcky.Monads.Option<'a>>() with
             override _.Generator =
-                Gen.frequency [(1, gen { return Option<'a>.None }); (7, Arb.generate |> Gen.filter FunckyGenerators.isNotNull |> Gen.map Option.Some)]
+                Gen.frequency [(1, gen { return Option<'a>.None }); (7, Arb.generate<NonNull<'a>> |> Gen.map (fun x -> x.Get) |> Gen.map Option.Some)]
             override _.Shrinker o =
                 o.Match(none = Seq.empty, some = fun x -> seq { yield Option<'a>.None; for x' in Arb.shrink x -> Option.Some x' })
         }
 
     static member generateLazy<'a>() =
-        Arb.fromGen (Arb.generate<'a> |> Gen.map Lazy.Return)
+        Arb.fromGen (Arb.generate<NonNull<'a>> |> Gen.map (fun x -> x.Get) |> Gen.map Lazy.Return)
 
     static member generateReader<'env, 'a>() =
-        Arb.fromGen (Arb.generate<Func<'env, 'a>> |> Gen.map Reader<'env>.FromFunc)
+        Arb.fromGen (Arb.generate<Func<'env, NonNull<'a>>> |> Gen.map (fun f -> fun env -> f.Invoke(env).Get) |> Gen.map Reader<'env>.FromFunc)
 
     [<CompiledName("Register")>]
-
     static member register() = Arb.registerByType typeof<FunckyGenerators> |> ignore
-
-    static member private isNotNull x = not (Object.ReferenceEquals(x, null))

--- a/Funcky.FsCheck/FunckyGenerators.fs
+++ b/Funcky.FsCheck/FunckyGenerators.fs
@@ -50,7 +50,7 @@ type FunckyGenerators =
     static member option<'a>() =
         { new Arbitrary<Funcky.Monads.Option<'a>>() with
             override _.Generator =
-                Gen.frequency [(1, gen { return Option<'a>.None }); (7, Arb.generate |> Gen.map Option.Some)]
+                Gen.frequency [(1, gen { return Option<'a>.None }); (7, Arb.generate |> Gen.filter FunckyGenerators.isNotNull |> Gen.map Option.Some)]
             override _.Shrinker o =
                 o.Match(none = Seq.empty, some = fun x -> seq { yield Option<'a>.None; for x' in Arb.shrink x -> Option.Some x' })
         }
@@ -62,4 +62,7 @@ type FunckyGenerators =
         Arb.fromGen (Arb.generate<Func<'env, 'a>> |> Gen.map Reader<'env>.FromFunc)
 
     [<CompiledName("Register")>]
+
     static member register() = Arb.registerByType typeof<FunckyGenerators> |> ignore
+
+    static member private isNotNull x = not (Object.ReferenceEquals(x, null))

--- a/Funcky.Test/Extensions/EnumerableExtensions/SequenceTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/SequenceTest.cs
@@ -9,9 +9,7 @@ namespace Funcky.Test.Extensions.EnumerableExtensions;
 public sealed class SequenceTest
 {
     public SequenceTest()
-    {
-        FunckyGenerators.Register();
-    }
+        => FunckyGenerators.Register();
 
     [Property]
     public Property SequencingEitherReturnsLeftWhenOneOrMoreElementsAreLeft(IList<Either<int, int>> list)

--- a/Funcky.Test/Monads/EitherTest.cs
+++ b/Funcky.Test/Monads/EitherTest.cs
@@ -1,10 +1,14 @@
 using FsCheck;
 using FsCheck.Xunit;
+using Funcky.FsCheck;
 
 namespace Funcky.Test.Monads;
 
 public sealed partial class EitherTest
 {
+    public EitherTest()
+        => FunckyGenerators.Register();
+
     [Fact]
     public void CreateEitherLeftAndMatchCorrectly()
     {

--- a/Funcky.Test/Monads/LazyTest.cs
+++ b/Funcky.Test/Monads/LazyTest.cs
@@ -1,5 +1,9 @@
+using Funcky.FsCheck;
+
 namespace Funcky.Test.Monads;
 
 public sealed partial class LazyTest
 {
+    public LazyTest()
+        => FunckyGenerators.Register();
 }

--- a/Funcky.Test/Monads/ReaderTest.cs
+++ b/Funcky.Test/Monads/ReaderTest.cs
@@ -1,8 +1,13 @@
+using Funcky.FsCheck;
+
 namespace Funcky.Test.Monads;
 
 public sealed partial class ReaderTest
 {
     private string _sideEffect = string.Empty;
+
+    public ReaderTest()
+        => FunckyGenerators.Register();
 
     [Fact]
     public void YouCanApplyEnvironmentToReaderMonad()

--- a/Funcky.Test/Monads/ResultTest.Monad.cs
+++ b/Funcky.Test/Monads/ResultTest.Monad.cs
@@ -1,31 +1,45 @@
 using FsCheck;
 using FsCheck.Xunit;
-using Funcky.FsCheck;
+using Funcky.Test.TestUtils;
 using Result = Funcky.Monads.Result;
 
 namespace Funcky.Test.Monads;
 
 public sealed partial class ResultTest
 {
-    public ResultTest() => FunckyGenerators.Register();
-
     [Property]
     public Property AssociativityHolds(
         Result<int> input,
         Func<int, Result<int>> selectorOne,
         Func<int, Result<int>> selectorTwo)
-    {
-        Result<int> CombinedSelector(int x) => selectorOne(x).SelectMany(selectorTwo);
-
-        return (input.SelectMany(selectorOne).SelectMany(selectorTwo) == input.SelectMany(CombinedSelector))
-            .ToProperty();
-    }
+        => CheckAssert.Equal(input.SelectMany(selectorOne).SelectMany(selectorTwo), input.SelectMany(Combine(selectorOne, selectorTwo)));
 
     [Property]
     public Property RightIdentityHolds(Result<int> input)
-        => (input.SelectMany(Result.Return) == input).ToProperty();
+        => CheckAssert.Equal(input, input.SelectMany(Result.Return));
 
     [Property]
     public Property LeftIdentityHolds(int input, Func<int, Result<int>> selector)
-        => (Result.Return(input).SelectMany(selector) == selector(input)).ToProperty();
+        => CheckAssert.Equal(Result.Return(input).SelectMany(selector), selector(input));
+
+    [Property]
+    public Property AssociativityHoldsWithReferenceTypes(
+        Result<string> input,
+        Func<string, Result<string>> selectorOne,
+        Func<string, Result<string>> selectorTwo)
+        => CheckAssert.Equal(input.SelectMany(selectorOne).SelectMany(selectorTwo), input.SelectMany(Combine(selectorOne, selectorTwo)));
+
+    [Property]
+    public Property RightIdentityHoldsWithReferenceTypes(Result<string> input)
+        => CheckAssert.Equal(input, input.SelectMany(Result.Return));
+
+    [Property]
+    public Property LeftIdentityHoldsWithReferenceTypes(string? input, Func<string, Result<string>> selector)
+        => input is null
+            ? true.ToProperty()
+            : CheckAssert.Equal(Result.Return(input).SelectMany(selector), selector(input));
+
+    private static Func<TItem, Result<TItem>> Combine<TItem>(Func<TItem, Result<TItem>> functionA, Func<TItem, Result<TItem>> functionB)
+        => input
+            => functionA(input).SelectMany(functionB);
 }

--- a/Funcky.Test/Monads/ResultTest.cs
+++ b/Funcky.Test/Monads/ResultTest.cs
@@ -1,10 +1,14 @@
 using System.Runtime.CompilerServices;
+using Funcky.FsCheck;
 using Xunit.Sdk;
 
 namespace Funcky.Test.Monads;
 
 public sealed partial class ResultTest
 {
+    public ResultTest()
+        => FunckyGenerators.Register();
+
     [Fact]
     public void CreateResultOkAndMatchCorrectly()
     {

--- a/Funcky.Test/TestUtils/CheckAssert.cs
+++ b/Funcky.Test/TestUtils/CheckAssert.cs
@@ -1,6 +1,7 @@
 using FsCheck;
 
 namespace Funcky.Test.TestUtils;
+
 internal static class CheckAssert
 {
     public static Property Equal<T>(T expected, T actual)

--- a/Funcky.Test/TestUtils/CheckAssert.cs
+++ b/Funcky.Test/TestUtils/CheckAssert.cs
@@ -1,0 +1,29 @@
+using FsCheck;
+
+namespace Funcky.Test.TestUtils;
+internal static class CheckAssert
+{
+    public static Property Equal<T>(T expected, T actual)
+        where T : IEquatable<T>
+        => expected
+            .Equals(actual)
+            .ToProperty();
+
+    public static Property Equal<TItem>(Lazy<TItem> expected, Lazy<TItem> actual)
+        where TItem : IEquatable<TItem>
+        => expected.Value
+            .Equals(actual.Value)
+            .ToProperty();
+
+    public static Property Equal<TItem>(Reader<TItem, TItem> expected, Reader<TItem, TItem> actual, TItem environment)
+        where TItem : IEquatable<TItem>
+        => Sequence
+            .Return(environment)
+            .All(EqualGivenEnvironment(expected, actual))
+            .ToProperty();
+
+    private static Func<TItem, bool> EqualGivenEnvironment<TItem>(Reader<TItem, TItem> expected, Reader<TItem, TItem> actual)
+        where TItem : IEquatable<TItem>
+        => environment
+            => expected(environment).Equals(actual(environment));
+}


### PR DESCRIPTION
* All tests are property tests now
* The code looks the same when possible
* Add tests for reference types
* The constructor moved to the main partial
* fixed Option generator
* helper for Property tests