### PR TITLE
Prevent accidental disposal of original buffer

### DIFF
--- a/Funcky.Async.Test/Extensions/AsyncEnumerableExtensions/MemoizeTest.cs
+++ b/Funcky.Async.Test/Extensions/AsyncEnumerableExtensions/MemoizeTest.cs
@@ -65,4 +65,27 @@ public sealed class MemoizeTest
         Assert.True(await enumerator2.MoveNextAsync());
         Assert.Equal(5, enumerator2.Current);
     }
+
+    [Fact]
+    public async Task DisposingAMemoizedBufferDoesNotDisposeOriginalBuffer()
+    {
+        var source = AsyncEnumerateOnce.Create(Enumerable.Empty<int>());
+        await using var firstMemoization = source.Memoize();
+
+        await using (firstMemoization.Memoize())
+        {
+        }
+
+        await firstMemoization.ForEachAsync(NoOperation<int>);
+    }
+
+    [Fact]
+    public async Task MemoizingAMemoizedBufferTwiceReturnsTheOriginalObject()
+    {
+        var source = AsyncEnumerateOnce.Create(Enumerable.Empty<int>());
+        await using var memoized = source.Memoize();
+        await using var memoizedBuffer = memoized.Memoize();
+        await using var memoizedBuffer2 = memoizedBuffer.Memoize();
+        Assert.Same(memoizedBuffer, memoizedBuffer2);
+    }
 }

--- a/Funcky.Async.Test/Extensions/AsyncEnumerableExtensions/MemoizeTest.cs
+++ b/Funcky.Async.Test/Extensions/AsyncEnumerableExtensions/MemoizeTest.cs
@@ -1,6 +1,6 @@
 using Funcky.Async.Test.TestUtilities;
 
-namespace Funcky.Test;
+namespace Funcky.Async.Test.Extensions.AsyncEnumerableExtensions;
 
 public sealed class MemoizeTest
 {

--- a/Funcky.Async/Extensions/AsyncEnumerableExtensions/Memoize.cs
+++ b/Funcky.Async/Extensions/AsyncEnumerableExtensions/Memoize.cs
@@ -17,9 +17,7 @@ public static partial class AsyncEnumerableExtensions
             : MemoizedAsyncBuffer.Create(sequence);
 
     private static IAsyncBuffer<TSource> Borrow<TSource>(IAsyncBuffer<TSource> buffer)
-        => buffer is BorrowedAsyncBuffer<TSource> borrowed
-            ? borrowed
-            : new BorrowedAsyncBuffer<TSource>(buffer);
+        => buffer as BorrowedAsyncBuffer<TSource> ?? new BorrowedAsyncBuffer<TSource>(buffer);
 
     private static class MemoizedAsyncBuffer
     {

--- a/Funcky.Test/Extensions/EnumerableExtensions/MemoizeTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/MemoizeTest.cs
@@ -65,4 +65,27 @@ public sealed class MemoizeTest
         Assert.True(enumerator2.MoveNext());
         Assert.Equal(5, enumerator2.Current);
     }
+
+    [Fact]
+    public void DisposingAMemoizedBufferDoesNotDisposeOriginalBuffer()
+    {
+        var source = EnumerateOnce.Create(Enumerable.Empty<int>());
+        using var firstMemoization = source.Memoize();
+
+        using (firstMemoization.Memoize())
+        {
+        }
+
+        firstMemoization.ForEach(NoOperation);
+    }
+
+    [Fact]
+    public void MemoizingAMemoizedBufferTwiceReturnsTheOriginalObject()
+    {
+        var source = EnumerateOnce.Create(Enumerable.Empty<int>());
+        using var memoized = source.Memoize();
+        using var memoizedBuffer = memoized.Memoize();
+        using var memoizedBuffer2 = memoizedBuffer.Memoize();
+        Assert.Same(memoizedBuffer, memoizedBuffer2);
+    }
 }

--- a/Funcky/Extensions/EnumerableExtensions/Memoize.cs
+++ b/Funcky/Extensions/EnumerableExtensions/Memoize.cs
@@ -21,9 +21,7 @@ public static partial class EnumerableExtensions
 
     [SuppressMessage("IDisposableAnalyzers", "IDISP015: Member should not return created and cached instance.", Justification = "False positive.")]
     private static IBuffer<TSource> Borrow<TSource>(IBuffer<TSource> buffer)
-        => buffer is BorrowedBuffer<TSource> borrowed
-            ? borrowed
-            : new BorrowedBuffer<TSource>(buffer);
+        => buffer as BorrowedBuffer<TSource> ?? new BorrowedBuffer<TSource>(buffer);
 
     private static class MemoizedBuffer
     {

--- a/Funcky/Extensions/EnumerableExtensions/Memoize.cs
+++ b/Funcky/Extensions/EnumerableExtensions/Memoize.cs
@@ -50,7 +50,7 @@ public static partial class EnumerableExtensions
         {
             if (_disposed)
             {
-                throw new ObjectDisposedException(nameof(MemoizedBuffer));
+                throw new ObjectDisposedException(nameof(BorrowedBuffer<T>));
             }
         }
     }


### PR DESCRIPTION
The contract of `Memoize` is that the caller owns the returned disposable.
Due to the optimization where we return immediately if the input is a buffer a caller might accidentally dispose a buffer that is owned by someone else. 