### PR TITLE
Fix `ParseCacheControlHeaderValueOrNone` for empty inputs

### DIFF
--- a/Funcky.Test/Extensions/ParseExtensions/ParseExtensionsTest.CacheControlHeaderValue.cs
+++ b/Funcky.Test/Extensions/ParseExtensions/ParseExtensionsTest.CacheControlHeaderValue.cs
@@ -1,0 +1,12 @@
+namespace Funcky.Test.Extensions.ParseExtensions;
+
+public sealed partial class ParseExtensionsTest
+{
+    /// <summary>Backport of https://github.com/dotnet/runtime/pull/74863.</summary>
+    [Fact]
+    public void ReturnsEmptyValueForEmptyString()
+    {
+        var value = FunctionalAssert.Some(string.Empty.ParseCacheControlHeaderValueOrNone());
+        Assert.Equal(string.Empty, value.ToString());
+    }
+}

--- a/Funcky.Test/Extensions/ParseExtensions/ParseExtensionsTest.Version.cs
+++ b/Funcky.Test/Extensions/ParseExtensions/ParseExtensionsTest.Version.cs
@@ -3,7 +3,7 @@ using FsCheck.Xunit;
 
 namespace Funcky.Test.Extensions.ParseExtensions;
 
-public sealed class ParseExtensionsTest
+public sealed partial class ParseExtensionsTest
 {
     [Theory]
     [InlineData("1.0")]

--- a/Funcky.Test/Funcky.Test.csproj
+++ b/Funcky.Test/Funcky.Test.csproj
@@ -19,6 +19,9 @@
         <ProjectReference Include="..\Funcky\Funcky.csproj" />
         <ProjectReference Include="..\Funcky.Xunit\Funcky.Xunit.csproj" />
     </ItemGroup>
+    <ItemGroup>
+        <Reference Include="System.Net.Http" Condition="'$(TargetFramework)' == 'net4.8'" />
+    </ItemGroup>
     <Import Project="..\Analyzers.props" />
     <Import Project="..\GlobalUsings.props" />
     <Import Project="..\GlobalUsings.Test.props" />

--- a/Funcky/Extensions/ParseExtensions/ParseExtensions.System.Net.Http.cs
+++ b/Funcky/Extensions/ParseExtensions/ParseExtensions.System.Net.Http.cs
@@ -27,6 +27,6 @@ public static partial class ParseExtensions
     [Pure]
     public static Option<CacheControlHeaderValue> ParseCacheControlHeaderValueOrNone(this string? candidate)
         => CacheControlHeaderValue.TryParse(candidate, out var result)
-            ? result!
+            ? result ?? new CacheControlHeaderValue()
             : Option<CacheControlHeaderValue>.None;
 }


### PR DESCRIPTION
Resolves #664