### PR TITLE
Implement ToNullable-extensions on Option.

### DIFF
--- a/Funcky.Test/Monads/OptionExtensionsTest.cs
+++ b/Funcky.Test/Monads/OptionExtensionsTest.cs
@@ -1,7 +1,14 @@
+using FsCheck;
+using FsCheck.Xunit;
+using Funcky.FsCheck;
+
 namespace Funcky.Test.Monads;
 
 public class OptionExtensionsTest
 {
+    public OptionExtensionsTest()
+        => FunckyGenerators.Register();
+
     public enum Reason
     {
         UserNotFound,
@@ -18,6 +25,28 @@ public class OptionExtensionsTest
         noUser.Switch(left: reason => Assert.Equal(Reason.UserNotFound, reason), right: _ => Assert.Fail("failed"));
         emptyUser.Switch(left: reason => Assert.Equal(Reason.NoFirstName, reason), right: _ => Assert.Fail("failed"));
         fullUser.Switch(left: _ => Assert.Fail("failed"), right: firstName => Assert.Equal("Name", firstName));
+    }
+
+    [Property]
+    public Property AnOptionWithAValueTypeCanBeConvertedToANullable(Option<int> input)
+    {
+        var nullable = input.ToNullable();
+
+        return input.Match(
+            none: () => nullable is null,
+            some: value => nullable == value)
+            .ToProperty();
+    }
+
+    [Property]
+    public Property AnOptionWithAReferenceTypeCanBeConvertedToNullableReferences(Option<string> input)
+    {
+        var nullable = input.ToNullable();
+
+        return input.Match(
+                none: () => nullable is null,
+                some: value => nullable == value)
+            .ToProperty();
     }
 
     private static Either<Reason, string> GetFirstNameFromUser(Func<Option<User>> getUser)

--- a/Funcky/Monads/Option/OptionExtensions.cs
+++ b/Funcky/Monads/Option/OptionExtensions.cs
@@ -1,3 +1,4 @@
+#pragma warning disable RS0026
 namespace Funcky.Monads;
 
 public static partial class OptionExtensions

--- a/Funcky/Monads/Option/OptionExtensions.cs
+++ b/Funcky/Monads/Option/OptionExtensions.cs
@@ -19,4 +19,16 @@ public static partial class OptionExtensions
             none: toLeft.Compose(left),
             some: Either<TLeft, TRight>.Right);
     }
+
+    public static TItem? ToNullable<TItem>(this Option<TItem> option, RequireStruct<TItem>? ω = null)
+        where TItem : struct
+        => option.Match(
+            none: null as TItem?,
+            some: item => item);
+
+    public static TItem? ToNullable<TItem>(this Option<TItem> option, RequireClass<TItem>? ω = null)
+        where TItem : class
+        => option.Match(
+            none: null as TItem,
+            some: item => item);
 }

--- a/Funcky/PublicAPI.Unshipped.txt
+++ b/Funcky/PublicAPI.Unshipped.txt
@@ -1,4 +1,9 @@
-#nullable enable
+﻿#nullable enable
+Funcky.RequireClass<T>
+Funcky.RequireClass<T>.RequireClass() -> void
+Funcky.RequireStruct<T>
 static Funcky.Extensions.EnumerableExtensions.ElementAtOrNone<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Index index) -> Funcky.Monads.Option<TSource>
 static Funcky.Extensions.QueryableExtensions.ElementAtOrNone<TSource>(this System.Linq.IQueryable<TSource>! source, int index) -> Funcky.Monads.Option<TSource>
 static Funcky.Extensions.QueryableExtensions.ElementAtOrNone<TSource>(this System.Linq.IQueryable<TSource>! source, System.Index index) -> Funcky.Monads.Option<TSource>
+static Funcky.Monads.OptionExtensions.ToNullable<TItem>(this Funcky.Monads.Option<TItem!> option, Funcky.RequireClass<TItem!>? ω = null) -> TItem?
+static Funcky.Monads.OptionExtensions.ToNullable<TItem>(this Funcky.Monads.Option<TItem> option, Funcky.RequireStruct<TItem>? ω = null) -> TItem?

--- a/Funcky/PublicAPI.Unshipped.txt
+++ b/Funcky/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
-﻿#nullable enable
+#nullable enable
 Funcky.RequireClass<T>
-Funcky.RequireClass<T>.RequireClass() -> void
 Funcky.RequireStruct<T>
 static Funcky.Extensions.EnumerableExtensions.ElementAtOrNone<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Index index) -> Funcky.Monads.Option<TSource>
 static Funcky.Extensions.QueryableExtensions.ElementAtOrNone<TSource>(this System.Linq.IQueryable<TSource>! source, int index) -> Funcky.Monads.Option<TSource>

--- a/Funcky/RequireClass.cs
+++ b/Funcky/RequireClass.cs
@@ -1,10 +1,8 @@
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 using static System.ComponentModel.EditorBrowsableState;
 
 namespace Funcky;
 
-[SuppressMessage("ApiDesign", "RS0041", Justification = "This is just a helper type")]
 [EditorBrowsable(Never)]
 public sealed record RequireClass<T>
     where T : class;

--- a/Funcky/RequireClass.cs
+++ b/Funcky/RequireClass.cs
@@ -1,7 +1,10 @@
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using static System.ComponentModel.EditorBrowsableState;
 
 namespace Funcky;
 
 [SuppressMessage("ApiDesign", "RS0041", Justification = "This is just a helper type")]
+[EditorBrowsable(Never)]
 public sealed record RequireClass<T>
     where T : class;

--- a/Funcky/RequireClass.cs
+++ b/Funcky/RequireClass.cs
@@ -1,0 +1,7 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Funcky;
+
+[SuppressMessage("ApiDesign", "RS0041", Justification = "This is just a helper type")]
+public sealed record RequireClass<T>
+    where T : class;

--- a/Funcky/RequireStruct.cs
+++ b/Funcky/RequireStruct.cs
@@ -1,0 +1,4 @@
+namespace Funcky;
+
+public sealed record RequireStruct<T>
+    where T : struct;

--- a/Funcky/RequireStruct.cs
+++ b/Funcky/RequireStruct.cs
@@ -1,4 +1,8 @@
+using System.ComponentModel;
+using static System.ComponentModel.EditorBrowsableState;
+
 namespace Funcky;
 
+[EditorBrowsable(Never)]
 public sealed record RequireStruct<T>
     where T : struct;


### PR DESCRIPTION
Implements #675 

I experimented a bit
* The RequireStruct and RequireClass are back!
* I think it is not possible to implement it as a member function.
* It is not possible to have the same typename with different constraints.
* We could avoid the RequireStruct and RequireClass hack when we would implement the Extensions with different Names.