### PR TITLE
Change generic constraint helpers to `class`

### DIFF
--- a/Funcky/PublicAPI.Unshipped.txt
+++ b/Funcky/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 #nullable enable
 Funcky.RequireClass<T>
+Funcky.RequireClass<T>.RequireClass() -> void
 Funcky.RequireStruct<T>
+Funcky.RequireStruct<T>.RequireStruct() -> void
 static Funcky.Extensions.EnumerableExtensions.ElementAtOrNone<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Index index) -> Funcky.Monads.Option<TSource>
 static Funcky.Extensions.QueryableExtensions.ElementAtOrNone<TSource>(this System.Linq.IQueryable<TSource>! source, int index) -> Funcky.Monads.Option<TSource>
 static Funcky.Extensions.QueryableExtensions.ElementAtOrNone<TSource>(this System.Linq.IQueryable<TSource>! source, System.Index index) -> Funcky.Monads.Option<TSource>

--- a/Funcky/RequireClass.cs
+++ b/Funcky/RequireClass.cs
@@ -4,5 +4,7 @@ using static System.ComponentModel.EditorBrowsableState;
 namespace Funcky;
 
 [EditorBrowsable(Never)]
-public sealed record RequireClass<T>
-    where T : class;
+public sealed class RequireClass<T>
+    where T : class
+{
+}

--- a/Funcky/RequireStruct.cs
+++ b/Funcky/RequireStruct.cs
@@ -4,5 +4,7 @@ using static System.ComponentModel.EditorBrowsableState;
 namespace Funcky;
 
 [EditorBrowsable(Never)]
-public sealed record RequireStruct<T>
-    where T : struct;
+public sealed class RequireStruct<T>
+    where T : struct
+{
+}


### PR DESCRIPTION
We don't need all the members generated by `record`, right?