### PR TITLE
Add missing `OrElse` and `GetOrElse` methods to `Result` and `Either`

### DIFF
--- a/Funcky/Monads/Either/Either.Convenience.cs
+++ b/Funcky/Monads/Either/Either.Convenience.cs
@@ -16,6 +16,16 @@ public readonly partial struct Either<TLeft, TRight>
         return this;
     }
 
+    /// <remarks>Careful! This overload discards the left value.</remarks>
+    [Pure]
+    public Either<TLeft, TRight> OrElse(Either<TLeft, TRight> fallback)
+        => Match(left: _ => fallback, right: Either<TLeft>.Return);
+
+    [Pure]
+    public Either<TLeft, TRight> OrElse(Func<TLeft, Either<TLeft, TRight>> fallback)
+        => Match(left: fallback, right: Either<TLeft>.Return);
+
+    /// <remarks>Careful! This overload discards the left value.</remarks>
     [Pure]
     public TRight GetOrElse(TRight fallback)
         => Match(left: _ => fallback, right: Identity);

--- a/Funcky/Monads/Result/Result.Convenience.cs
+++ b/Funcky/Monads/Result/Result.Convenience.cs
@@ -13,10 +13,26 @@ public readonly partial struct Result<TValidResult>
         return this;
     }
 
+    /// <remarks>Careful! This overload discards the exception.</remarks>
+    [Pure]
+    public Result<TValidResult> OrElse(Result<TValidResult> fallback)
+        => Match(error: _ => fallback, ok: Result.Return);
+
+    [Pure]
+    public Result<TValidResult> OrElse(Func<Exception, Result<TValidResult>> fallback)
+        => Match(error: fallback, ok: Result.Return);
+
+    /// <remarks>Careful! This overload discards the exception.</remarks>
+    [Pure]
+    public TValidResult GetOrElse(TValidResult fallback)
+        => Match(error: _ => fallback, ok: Identity);
+
+    [Pure]
+    public TValidResult GetOrElse(Func<Exception, TValidResult> fallback)
+        => Match(error: fallback, ok: Identity);
+
     public TValidResult GetOrThrow()
-        => Match(
-            ok: Identity,
-            error: ThrowWithOriginalStackTrace);
+        => GetOrElse(ThrowWithOriginalStackTrace);
 
     private static TValidResult ThrowWithOriginalStackTrace(Exception exception)
     {

--- a/Funcky/PublicAPI.Unshipped.txt
+++ b/Funcky/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+Funcky.Monads.Either<TLeft, TRight>.OrElse(Funcky.Monads.Either<TLeft, TRight> fallback) -> Funcky.Monads.Either<TLeft, TRight>
+Funcky.Monads.Either<TLeft, TRight>.OrElse(System.Func<TLeft, Funcky.Monads.Either<TLeft, TRight>>! fallback) -> Funcky.Monads.Either<TLeft, TRight>
+Funcky.Monads.Result<TValidResult>.GetOrElse(System.Func<System.Exception!, TValidResult>! fallback) -> TValidResult
+Funcky.Monads.Result<TValidResult>.GetOrElse(TValidResult fallback) -> TValidResult
+Funcky.Monads.Result<TValidResult>.OrElse(Funcky.Monads.Result<TValidResult> fallback) -> Funcky.Monads.Result<TValidResult>
+Funcky.Monads.Result<TValidResult>.OrElse(System.Func<System.Exception!, Funcky.Monads.Result<TValidResult>>! fallback) -> Funcky.Monads.Result<TValidResult>


### PR DESCRIPTION
I noticed that not all of our alternative monads have the same `OrElse` and `GetOrElse` methods while trying to generalize the match analyzer in #736.

Some of these overloads are potentially dangerous as they discard the error state's value.
To be fair we already have one of those overloads for Either