### PR TITLE
Declare Funcky.XUnit incompatibility with xunit 2.5 and 2.6 releases

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,8 +7,8 @@
 		<PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
 		<PackageVersion Include="System.Collections.Immutable" Version="1.7.1" />
 		<PackageVersion Include="System.Text.Json" Version="5.0.0" />
-		<PackageVersion Include="xunit.assert" Version="[2.4.0, 3)" />
-		<PackageVersion Include="xunit.extensibility.core" Version="[2.4.0, 3)" />
+		<PackageVersion Include="xunit.assert" Version="[2.4.0, 2.5)" />
+		<PackageVersion Include="xunit.extensibility.core" Version="[2.4.0, 2.5)" />
 		<PackageVersion Include="System.Linq.Async" Version="[5.0.0, 7)" />
 	</ItemGroup>
 	<ItemGroup Label="Build Dependencies">


### PR DESCRIPTION
This should fix problems using our Library.  (See #777)

I ran into this twice before I understood what the problem was.