### PR TITLE
Experimental idea: IsBetween with explicit Inclusive and Exlusive boundaries

### DIFF
--- a/Funcky.Test/Extensions/NumberExtensionsTest.cs
+++ b/Funcky.Test/Extensions/NumberExtensionsTest.cs
@@ -1,0 +1,12 @@
+namespace Funcky.Test.Extensions;
+
+public class NumberExtensionsTest
+{
+    [Fact]
+    public void Example()
+    {
+        var position = 12;
+
+        Assert.True(position.IsBetween<Including, Excluding>(20, 0));
+    }
+}

--- a/Funcky/Extensions/Excluding.cs
+++ b/Funcky/Extensions/Excluding.cs
@@ -1,0 +1,13 @@
+namespace Funcky.Extensions;
+
+public class Excluding : IIntervalBoundary
+{
+    private Excluding(int number)
+    {
+        Value = number;
+    }
+
+    public int Value { get; }
+
+    public static implicit operator Excluding(int number) => new(number);
+}

--- a/Funcky/Extensions/IIntervalBoundary.cs
+++ b/Funcky/Extensions/IIntervalBoundary.cs
@@ -1,0 +1,6 @@
+namespace Funcky.Extensions;
+
+public interface IIntervalBoundary
+{
+    int Value { get; }
+}

--- a/Funcky/Extensions/Including.cs
+++ b/Funcky/Extensions/Including.cs
@@ -1,0 +1,13 @@
+namespace Funcky.Extensions;
+
+public class Including : IIntervalBoundary
+{
+    private Including(int number)
+    {
+        Value = number;
+    }
+
+    public int Value { get; }
+
+    public static implicit operator Including(int number) => new(number);
+}

--- a/Funcky/Extensions/NumberExtensions.cs
+++ b/Funcky/Extensions/NumberExtensions.cs
@@ -1,0 +1,35 @@
+namespace Funcky.Extensions;
+
+public static class NumberExtensions
+{
+    public static bool IsBetween<TFrom, TTo>(this int number, TFrom from, TTo to)
+        where TFrom : IIntervalBoundary
+        where TTo : IIntervalBoundary
+        => from.Value < to.Value
+            ? IsBetweenForward(number, from, to)
+            : IsBetweenBackward(number, from, to);
+
+    private static bool IsBetweenForward<TFrom, TTo>(int number, TFrom from, TTo to)
+        where TFrom : IIntervalBoundary
+        where TTo : IIntervalBoundary
+        => (from, to) switch
+        {
+            (Including, Including) => from.Value <= number && number <= to.Value,
+            (Including, Excluding) => from.Value <= number && number < to.Value,
+            (Excluding, Including) => from.Value < number && number <= to.Value,
+            (Excluding, Excluding) => from.Value < number && number < to.Value,
+            _ => false,
+        };
+
+    private static bool IsBetweenBackward<TFrom, TTo>(int number, TFrom from, TTo to)
+        where TFrom : IIntervalBoundary
+        where TTo : IIntervalBoundary
+        => (from, to) switch
+        {
+            (Including, Including) => from.Value >= number && number >= to.Value,
+            (Including, Excluding) => from.Value >= number && number > to.Value,
+            (Excluding, Including) => from.Value > number && number >= to.Value,
+            (Excluding, Excluding) => from.Value > number && number > to.Value,
+            _ => false,
+        };
+}


### PR DESCRIPTION
Main Idea:

I want a "IsBetween" extension on number types (just int in the experiment) which I can chose if the boundary are inclusive or exclusive.

```cs
12.IsBetween<Including, Excluding>(0, 20)
```

This was a lot easier than I thought, I defined a common interface IIntervalBoundary and two implementations Inclusive and Exclusive with private constructors and public implicit operators.