### PR TITLE
Add an `Fn` function to help with type inference

### DIFF
--- a/Funcky.Test/FunctionalClass/FnTest.cs
+++ b/Funcky.Test/FunctionalClass/FnTest.cs
@@ -1,0 +1,14 @@
+namespace Funcky.Test.FunctionalClass;
+
+public sealed class FnTest
+{
+    [Fact]
+    public void FnHelpsToInferAMethodGroupsNaturalType()
+    {
+        var powCurried = Curry(Fn(Math.Pow));
+        var powUncurried = Uncurry(Fn(CurriedPow));
+        var flipped = Flip(Fn(Math.Pow));
+    }
+
+    private static Func<double, double> CurriedPow(double x) => y => Math.Pow(x, y);
+}

--- a/Funcky/Extensions/ActionExtensions/Compose.cs
+++ b/Funcky/Extensions/ActionExtensions/Compose.cs
@@ -6,6 +6,7 @@ public static partial class ActionExtensions
     /// Function composition with action.
     /// </summary>
     /// <returns>f ∘ g,v => f(g(v)).</returns>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<TInput> Compose<TInput, TIntermediate>(this Action<TIntermediate> f, Func<TInput, TIntermediate> g)
         => v => f(g(v));
@@ -14,6 +15,7 @@ public static partial class ActionExtensions
     /// Function composition with Action.
     /// </summary>
     /// <returns>f ∘ g, () => f(g()).</returns>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action Compose<TIntermediate>(this Action<TIntermediate> f, Func<TIntermediate> g)
         => () => f(g());

--- a/Funcky/Extensions/ActionExtensions/Curry.cs
+++ b/Funcky/Extensions/ActionExtensions/Curry.cs
@@ -5,6 +5,7 @@ public static partial class ActionExtensions
     /// <summary>
     /// Curries the given action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Action<T2>> Curry<T1, T2>(this Action<T1, T2> action)
         => p1 => p2 => action(p1, p2);
@@ -12,6 +13,7 @@ public static partial class ActionExtensions
     /// <summary>
     /// Curries the given action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Action<T3>>> Curry<T1, T2, T3>(this Action<T1, T2, T3> action)
         => p1 => p2 => p3 => action(p1, p2, p3);
@@ -19,6 +21,7 @@ public static partial class ActionExtensions
     /// <summary>
     /// Curries the given action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, Action<T4>>>> Curry<T1, T2, T3, T4>(this Action<T1, T2, T3, T4> action)
         => p1 => p2 => p3 => p4 => action(p1, p2, p3, p4);
@@ -26,6 +29,7 @@ public static partial class ActionExtensions
     /// <summary>
     /// Curries the given action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, Func<T4, Action<T5>>>>> Curry<T1, T2, T3, T4, T5>(this Action<T1, T2, T3, T4, T5> action)
         => p1 => p2 => p3 => p4 => p5 => action(p1, p2, p3, p4, p5);
@@ -33,6 +37,7 @@ public static partial class ActionExtensions
     /// <summary>
     /// Curries the given action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Action<T6>>>>>> Curry<T1, T2, T3, T4, T5, T6>(this Action<T1, T2, T3, T4, T5, T6> action)
         => p1 => p2 => p3 => p4 => p5 => p6 => action(p1, p2, p3, p4, p5, p6);
@@ -40,6 +45,7 @@ public static partial class ActionExtensions
     /// <summary>
     /// Curries the given action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Func<T6, Action<T7>>>>>>> Curry<T1, T2, T3, T4, T5, T6, T7>(this Action<T1, T2, T3, T4, T5, T6, T7> action)
         => p1 => p2 => p3 => p4 => p5 => p6 => p7 => action(p1, p2, p3, p4, p5, p6, p7);
@@ -47,6 +53,7 @@ public static partial class ActionExtensions
     /// <summary>
     /// Curries the given action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Func<T6, Func<T7, Action<T8>>>>>>>> Curry<T1, T2, T3, T4, T5, T6, T7, T8>(this Action<T1, T2, T3, T4, T5, T6, T7, T8> action)
         => p1 => p2 => p3 => p4 => p5 => p6 => p7 => p8 => action(p1, p2, p3, p4, p5, p6, p7, p8);

--- a/Funcky/Extensions/ActionExtensions/Flip.cs
+++ b/Funcky/Extensions/ActionExtensions/Flip.cs
@@ -3,15 +3,17 @@ namespace Funcky.Extensions;
 public static partial class ActionExtensions
 {
     /// <summary>
-    /// Flips the first two arguments of the function.
+    /// Flips the first two arguments of the action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<T2, T1> Flip<T1, T2>(this Action<T1, T2> function)
         => (p1, p2) => function(p2, p1);
 
     /// <summary>
-    /// Flips the first two arguments of the function.
+    /// Flips the first two arguments of the action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<T2, T1, T3> Flip<T1, T2, T3>(this Action<T1, T2, T3> action)
         => (p1, p2, p3) => action(p2, p1, p3);
@@ -19,6 +21,7 @@ public static partial class ActionExtensions
     /// <summary>
     /// Flips the first two arguments of the action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<T2, T1, T3, T4> Flip<T1, T2, T3, T4>(this Action<T1, T2, T3, T4> action)
         => (p1, p2, p3, p4) => action(p2, p1, p3, p4);
@@ -26,6 +29,7 @@ public static partial class ActionExtensions
     /// <summary>
     /// Flips the first two arguments of the action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<T2, T1, T3, T4, T5> Flip<T1, T2, T3, T4, T5>(this Action<T1, T2, T3, T4, T5> action)
         => (p1, p2, p3, p4, p5) => action(p2, p1, p3, p4, p5);
@@ -33,6 +37,7 @@ public static partial class ActionExtensions
     /// <summary>
     /// Flips the first two arguments of the action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<T2, T1, T3, T4, T5, T6> Flip<T1, T2, T3, T4, T5, T6>(this Action<T1, T2, T3, T4, T5, T6> action)
         => (p1, p2, p3, p4, p5, p6) => action(p2, p1, p3, p4, p5, p6);
@@ -40,6 +45,7 @@ public static partial class ActionExtensions
     /// <summary>
     /// Flips the first two arguments of the action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<T2, T1, T3, T4, T5, T6, T7> Flip<T1, T2, T3, T4, T5, T6, T7>(this Action<T1, T2, T3, T4, T5, T6, T7> action)
         => (p1, p2, p3, p4, p5, p6, p7) => action(p2, p1, p3, p4, p5, p6, p7);
@@ -47,6 +53,7 @@ public static partial class ActionExtensions
     /// <summary>
     /// Flips the first two arguments of the action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<T2, T1, T3, T4, T5, T6, T7, T8> Flip<T1, T2, T3, T4, T5, T6, T7, T8>(this Action<T1, T2, T3, T4, T5, T6, T7, T8> action)
         => (p1, p2, p3, p4, p5, p6, p7, p8) => action(p2, p1, p3, p4, p5, p6, p7, p8);

--- a/Funcky/Extensions/ActionExtensions/Uncurry.cs
+++ b/Funcky/Extensions/ActionExtensions/Uncurry.cs
@@ -3,50 +3,57 @@ namespace Funcky.Extensions;
 public static partial class ActionExtensions
 {
     /// <summary>
-    /// Transforms a curried action into a action that takes multiple arguments.
+    /// Transforms a curried action into an action that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<T1, T2> Uncurry<T1, T2>(this Func<T1, Action<T2>> action)
         => (p1, p2) => action(p1)(p2);
 
     /// <summary>
-    /// Transforms a curried action into a action that takes multiple arguments.
+    /// Transforms a curried action into an action that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<T1, T2, T3> Uncurry<T1, T2, T3>(this Func<T1, Func<T2, Action<T3>>> action)
         => (p1, p2, p3) => action(p1)(p2)(p3);
 
     /// <summary>
-    /// Transforms a curried action into a action that takes multiple arguments.
+    /// Transforms a curried action into an action that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<T1, T2, T3, T4> Uncurry<T1, T2, T3, T4>(this Func<T1, Func<T2, Func<T3, Action<T4>>>> action)
         => (p1, p2, p3, p4) => action(p1)(p2)(p3)(p4);
 
     /// <summary>
-    /// Transforms a curried action into a action that takes multiple arguments.
+    /// Transforms a curried action into an action that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<T1, T2, T3, T4, T5> Uncurry<T1, T2, T3, T4, T5>(this Func<T1, Func<T2, Func<T3, Func<T4, Action<T5>>>>> action)
         => (p1, p2, p3, p4, p5) => action(p1)(p2)(p3)(p4)(p5);
 
     /// <summary>
-    /// Transforms a curried action into a action that takes multiple arguments.
+    /// Transforms a curried action into an action that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<T1, T2, T3, T4, T5, T6> Uncurry<T1, T2, T3, T4, T5, T6>(this Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Action<T6>>>>>> action)
         => (p1, p2, p3, p4, p5, p6) => action(p1)(p2)(p3)(p4)(p5)(p6);
 
     /// <summary>
-    /// Transforms a curried action into a action that takes multiple arguments.
+    /// Transforms a curried action into an action that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<T1, T2, T3, T4, T5, T6, T7> Uncurry<T1, T2, T3, T4, T5, T6, T7>(this Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Func<T6, Action<T7>>>>>>> action)
         => (p1, p2, p3, p4, p5, p6, p7) => action(p1)(p2)(p3)(p4)(p5)(p6)(p7);
 
     /// <summary>
-    /// Transforms a curried action into a action that takes multiple arguments.
+    /// Transforms a curried action into an action that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<T1, T2, T3, T4, T5, T6, T7, T8> Uncurry<T1, T2, T3, T4, T5, T6, T7, T8>(this Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Func<T6, Func<T7, Action<T8>>>>>>>> action)
         => (p1, p2, p3, p4, p5, p6, p7, p8) => action(p1)(p2)(p3)(p4)(p5)(p6)(p7)(p8);

--- a/Funcky/Extensions/FuncExtensions/Compose.cs
+++ b/Funcky/Extensions/FuncExtensions/Compose.cs
@@ -6,6 +6,7 @@ public static partial class FuncExtensions
     /// Function composition.
     /// </summary>
     /// <returns>f ∘ g, v => f(g(v)).</returns>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<TInput, TOutput> Compose<TInput, TIntermediate, TOutput>(this Func<TIntermediate, TOutput> f, Func<TInput, TIntermediate> g)
         => v => f(g(v));
@@ -14,6 +15,7 @@ public static partial class FuncExtensions
     /// Function composition.
     /// </summary>
     /// <returns>f ∘ g,() => f(g()).</returns>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<TOutput> Compose<TIntermediate, TOutput>(this Func<TIntermediate, TOutput> f, Func<TIntermediate> g)
         => () => f(g());

--- a/Funcky/Extensions/FuncExtensions/Curry.cs
+++ b/Funcky/Extensions/FuncExtensions/Curry.cs
@@ -5,6 +5,7 @@ public static partial class FuncExtensions
     /// <summary>
     /// Curries the given function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, TResult>> Curry<T1, T2, TResult>(this Func<T1, T2, TResult> function)
         => p1 => p2 => function(p1, p2);
@@ -12,6 +13,7 @@ public static partial class FuncExtensions
     /// <summary>
     /// Curries the given function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, TResult>>> Curry<T1, T2, T3, TResult>(this Func<T1, T2, T3, TResult> function)
         => p1 => p2 => p3 => function(p1, p2, p3);
@@ -19,6 +21,7 @@ public static partial class FuncExtensions
     /// <summary>
     /// Curries the given function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, Func<T4, TResult>>>> Curry<T1, T2, T3, T4, TResult>(this Func<T1, T2, T3, T4, TResult> function)
         => p1 => p2 => p3 => p4 => function(p1, p2, p3, p4);
@@ -26,6 +29,7 @@ public static partial class FuncExtensions
     /// <summary>
     /// Curries the given function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, TResult>>>>> Curry<T1, T2, T3, T4, T5, TResult>(this Func<T1, T2, T3, T4, T5, TResult> function)
         => p1 => p2 => p3 => p4 => p5 => function(p1, p2, p3, p4, p5);
@@ -33,6 +37,7 @@ public static partial class FuncExtensions
     /// <summary>
     /// Curries the given function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Func<T6, TResult>>>>>> Curry<T1, T2, T3, T4, T5, T6, TResult>(this Func<T1, T2, T3, T4, T5, T6, TResult> function)
         => p1 => p2 => p3 => p4 => p5 => p6 => function(p1, p2, p3, p4, p5, p6);
@@ -40,6 +45,7 @@ public static partial class FuncExtensions
     /// <summary>
     /// Curries the given function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Func<T6, Func<T7, TResult>>>>>>> Curry<T1, T2, T3, T4, T5, T6, T7, TResult>(this Func<T1, T2, T3, T4, T5, T6, T7, TResult> function)
         => p1 => p2 => p3 => p4 => p5 => p6 => p7 => function(p1, p2, p3, p4, p5, p6, p7);
@@ -47,6 +53,7 @@ public static partial class FuncExtensions
     /// <summary>
     /// Curries the given function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Func<T6, Func<T7, Func<T8, TResult>>>>>>>> Curry<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(this Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> function)
         => p1 => p2 => p3 => p4 => p5 => p6 => p7 => p8 => function(p1, p2, p3, p4, p5, p6, p7, p8);

--- a/Funcky/Extensions/FuncExtensions/Flip.cs
+++ b/Funcky/Extensions/FuncExtensions/Flip.cs
@@ -5,6 +5,7 @@ public static partial class FuncExtensions
     /// <summary>
     /// Flips the first two arguments of the function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T2, T1, TResult> Flip<T1, T2, TResult>(this Func<T1, T2, TResult> function)
         => (p1, p2) => function(p2, p1);
@@ -12,6 +13,7 @@ public static partial class FuncExtensions
     /// <summary>
     /// Flips the first two arguments of the function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T2, T1, T3, TResult> Flip<T1, T2, T3, TResult>(this Func<T1, T2, T3, TResult> function)
         => (p1, p2, p3) => function(p2, p1, p3);
@@ -19,6 +21,7 @@ public static partial class FuncExtensions
     /// <summary>
     /// Flips the first two arguments of the function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T2, T1, T3, T4, TResult> Flip<T1, T2, T3, T4, TResult>(this Func<T1, T2, T3, T4, TResult> function)
         => (p1, p2, p3, p4) => function(p2, p1, p3, p4);
@@ -26,6 +29,7 @@ public static partial class FuncExtensions
     /// <summary>
     /// Flips the first two arguments of the function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T2, T1, T3, T4, T5, TResult> Flip<T1, T2, T3, T4, T5, TResult>(this Func<T1, T2, T3, T4, T5, TResult> function)
         => (p1, p2, p3, p4, p5) => function(p2, p1, p3, p4, p5);
@@ -33,6 +37,7 @@ public static partial class FuncExtensions
     /// <summary>
     /// Flips the first two arguments of the function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T2, T1, T3, T4, T5, T6, TResult> Flip<T1, T2, T3, T4, T5, T6, TResult>(this Func<T1, T2, T3, T4, T5, T6, TResult> function)
         => (p1, p2, p3, p4, p5, p6) => function(p2, p1, p3, p4, p5, p6);
@@ -40,6 +45,7 @@ public static partial class FuncExtensions
     /// <summary>
     /// Flips the first two arguments of the function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T2, T1, T3, T4, T5, T6, T7, TResult> Flip<T1, T2, T3, T4, T5, T6, T7, TResult>(this Func<T1, T2, T3, T4, T5, T6, T7, TResult> function)
         => (p1, p2, p3, p4, p5, p6, p7) => function(p2, p1, p3, p4, p5, p6, p7);
@@ -47,6 +53,7 @@ public static partial class FuncExtensions
     /// <summary>
     /// Flips the first two arguments of the function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T2, T1, T3, T4, T5, T6, T7, T8, TResult> Flip<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(this Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> function)
         => (p1, p2, p3, p4, p5, p6, p7, p8) => function(p2, p1, p3, p4, p5, p6, p7, p8);

--- a/Funcky/Extensions/FuncExtensions/Uncurry.cs
+++ b/Funcky/Extensions/FuncExtensions/Uncurry.cs
@@ -5,6 +5,7 @@ public static partial class FuncExtensions
     /// <summary>
     /// Transforms a curried function into a function that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, T2, TResult> Uncurry<T1, T2, TResult>(this Func<T1, Func<T2, TResult>> function)
         => (p1, p2) => function(p1)(p2);
@@ -12,6 +13,7 @@ public static partial class FuncExtensions
     /// <summary>
     /// Transforms a curried function into a function that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, T2, T3, TResult> Uncurry<T1, T2, T3, TResult>(this Func<T1, Func<T2, Func<T3, TResult>>> function)
         => (p1, p2, p3) => function(p1)(p2)(p3);
@@ -19,6 +21,7 @@ public static partial class FuncExtensions
     /// <summary>
     /// Transforms a curried function into a function that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, T2, T3, T4, TResult> Uncurry<T1, T2, T3, T4, TResult>(this Func<T1, Func<T2, Func<T3, Func<T4, TResult>>>> function)
         => (p1, p2, p3, p4) => function(p1)(p2)(p3)(p4);
@@ -26,6 +29,7 @@ public static partial class FuncExtensions
     /// <summary>
     /// Transforms a curried function into a function that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, T2, T3, T4, T5, TResult> Uncurry<T1, T2, T3, T4, T5, TResult>(this Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, TResult>>>>> function)
         => (p1, p2, p3, p4, p5) => function(p1)(p2)(p3)(p4)(p5);
@@ -33,6 +37,7 @@ public static partial class FuncExtensions
     /// <summary>
     /// Transforms a curried function into a function that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, T2, T3, T4, T5, T6, TResult> Uncurry<T1, T2, T3, T4, T5, T6, TResult>(this Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Func<T6, TResult>>>>>> function)
         => (p1, p2, p3, p4, p5, p6) => function(p1)(p2)(p3)(p4)(p5)(p6);
@@ -40,6 +45,7 @@ public static partial class FuncExtensions
     /// <summary>
     /// Transforms a curried function into a function that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, T2, T3, T4, T5, T6, T7, TResult> Uncurry<T1, T2, T3, T4, T5, T6, T7, TResult>(this Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Func<T6, Func<T7, TResult>>>>>>> function)
         => (p1, p2, p3, p4, p5, p6, p7) => function(p1)(p2)(p3)(p4)(p5)(p6)(p7);
@@ -47,6 +53,7 @@ public static partial class FuncExtensions
     /// <summary>
     /// Transforms a curried function into a function that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> Uncurry<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(this Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Func<T6, Func<T7, Func<T8, TResult>>>>>>>> function)
         => (p1, p2, p3, p4, p5, p6, p7, p8) => function(p1)(p2)(p3)(p4)(p5)(p6)(p7)(p8);

--- a/Funcky/Functional/Curry.cs
+++ b/Funcky/Functional/Curry.cs
@@ -5,6 +5,13 @@ public static partial class Functional
     /// <summary>
     /// Curries the given function.
     /// </summary>
+    /// <example>
+    /// Currying a method group using <see cref="Fn{T}"/> to help with inference:
+    /// <code><![CDATA[
+    /// var pow = Curry(Fn(Math.Pow));
+    /// ]]></code>
+    /// </example>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, TResult>> Curry<T1, T2, TResult>(Func<T1, T2, TResult> function)
         => p1 => p2 => function(p1, p2);
@@ -12,6 +19,14 @@ public static partial class Functional
     /// <summary>
     /// Curries the given function.
     /// </summary>
+    /// <example>
+    /// Currying a method group using <see cref="Fn{T}"/> to help with inference:
+    /// <code><![CDATA[
+    /// double LinearFunction(double m, double c, double x) => (m * x) + c;
+    /// var fn = Curry(Fn(LinearFunction));
+    /// ]]></code>
+    /// </example>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, TResult>>> Curry<T1, T2, T3, TResult>(Func<T1, T2, T3, TResult> function)
         => p1 => p2 => p3 => function(p1, p2, p3);
@@ -19,6 +34,7 @@ public static partial class Functional
     /// <summary>
     /// Curries the given function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, Func<T4, TResult>>>> Curry<T1, T2, T3, T4, TResult>(Func<T1, T2, T3, T4, TResult> function)
         => p1 => p2 => p3 => p4 => function(p1, p2, p3, p4);
@@ -26,6 +42,7 @@ public static partial class Functional
     /// <summary>
     /// Curries the given function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, TResult>>>>> Curry<T1, T2, T3, T4, T5, TResult>(Func<T1, T2, T3, T4, T5, TResult> function)
         => p1 => p2 => p3 => p4 => p5 => function(p1, p2, p3, p4, p5);
@@ -33,6 +50,7 @@ public static partial class Functional
     /// <summary>
     /// Curries the given function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Func<T6, TResult>>>>>> Curry<T1, T2, T3, T4, T5, T6, TResult>(Func<T1, T2, T3, T4, T5, T6, TResult> function)
         => p1 => p2 => p3 => p4 => p5 => p6 => function(p1, p2, p3, p4, p5, p6);
@@ -40,6 +58,7 @@ public static partial class Functional
     /// <summary>
     /// Curries the given function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Func<T6, Func<T7, TResult>>>>>>> Curry<T1, T2, T3, T4, T5, T6, T7, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, TResult> function)
         => p1 => p2 => p3 => p4 => p5 => p6 => p7 => function(p1, p2, p3, p4, p5, p6, p7);
@@ -47,6 +66,7 @@ public static partial class Functional
     /// <summary>
     /// Curries the given function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Func<T6, Func<T7, Func<T8, TResult>>>>>>>> Curry<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> function)
         => p1 => p2 => p3 => p4 => p5 => p6 => p7 => p8 => function(p1, p2, p3, p4, p5, p6, p7, p8);
@@ -54,6 +74,7 @@ public static partial class Functional
     /// <summary>
     /// Curries the given action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Action<T2>> Curry<T1, T2>(Action<T1, T2> action)
         => p1 => p2 => action(p1, p2);
@@ -61,6 +82,7 @@ public static partial class Functional
     /// <summary>
     /// Curries the given action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Action<T3>>> Curry<T1, T2, T3>(Action<T1, T2, T3> action)
         => p1 => p2 => p3 => action(p1, p2, p3);
@@ -68,6 +90,7 @@ public static partial class Functional
     /// <summary>
     /// Curries the given action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, Action<T4>>>> Curry<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action)
         => p1 => p2 => p3 => p4 => action(p1, p2, p3, p4);
@@ -75,6 +98,7 @@ public static partial class Functional
     /// <summary>
     /// Curries the given action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, Func<T4, Action<T5>>>>> Curry<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> action)
         => p1 => p2 => p3 => p4 => p5 => action(p1, p2, p3, p4, p5);
@@ -82,6 +106,7 @@ public static partial class Functional
     /// <summary>
     /// Curries the given action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Action<T6>>>>>> Curry<T1, T2, T3, T4, T5, T6>(Action<T1, T2, T3, T4, T5, T6> action)
         => p1 => p2 => p3 => p4 => p5 => p6 => action(p1, p2, p3, p4, p5, p6);
@@ -89,6 +114,7 @@ public static partial class Functional
     /// <summary>
     /// Curries the given action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Func<T6, Action<T7>>>>>>> Curry<T1, T2, T3, T4, T5, T6, T7>(Action<T1, T2, T3, T4, T5, T6, T7> action)
         => p1 => p2 => p3 => p4 => p5 => p6 => p7 => action(p1, p2, p3, p4, p5, p6, p7);
@@ -96,6 +122,7 @@ public static partial class Functional
     /// <summary>
     /// Curries the given action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Func<T6, Func<T7, Action<T8>>>>>>>> Curry<T1, T2, T3, T4, T5, T6, T7, T8>(Action<T1, T2, T3, T4, T5, T6, T7, T8> action)
         => p1 => p2 => p3 => p4 => p5 => p6 => p7 => p8 => action(p1, p2, p3, p4, p5, p6, p7, p8);

--- a/Funcky/Functional/Flip.cs
+++ b/Funcky/Functional/Flip.cs
@@ -7,6 +7,12 @@ public static partial class Functional
     /// <summary>
     /// Flips the first two arguments of the function.
     /// </summary>
+    /// <example>
+    /// Flipping a method group using <see cref="Fn{T}"/> to help with inference:
+    /// <code><![CDATA[
+    /// var flippedPow = Flip(Fn(Math.Pow));
+    /// ]]></code>
+    /// </example>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Func<T2, T1, TResult> Flip<T1, T2, TResult>(Func<T1, T2, TResult> function)
@@ -15,6 +21,7 @@ public static partial class Functional
     /// <summary>
     /// Flips the first two arguments of the function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Func<T2, T1, T3, TResult> Flip<T1, T2, T3, TResult>(Func<T1, T2, T3, TResult> function)
@@ -23,6 +30,7 @@ public static partial class Functional
     /// <summary>
     /// Flips the first two arguments of the function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Func<T2, T1, T3, T4, TResult> Flip<T1, T2, T3, T4, TResult>(Func<T1, T2, T3, T4, TResult> function)
@@ -31,6 +39,7 @@ public static partial class Functional
     /// <summary>
     /// Flips the first two arguments of the function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Func<T2, T1, T3, T4, T5, TResult> Flip<T1, T2, T3, T4, T5, TResult>(Func<T1, T2, T3, T4, T5, TResult> function)
@@ -39,6 +48,7 @@ public static partial class Functional
     /// <summary>
     /// Flips the first two arguments of the function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Func<T2, T1, T3, T4, T5, T6, TResult> Flip<T1, T2, T3, T4, T5, T6, TResult>(Func<T1, T2, T3, T4, T5, T6, TResult> function)
@@ -47,6 +57,7 @@ public static partial class Functional
     /// <summary>
     /// Flips the first two arguments of the function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Func<T2, T1, T3, T4, T5, T6, T7, TResult> Flip<T1, T2, T3, T4, T5, T6, T7, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, TResult> function)
@@ -55,22 +66,25 @@ public static partial class Functional
     /// <summary>
     /// Flips the first two arguments of the function.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Func<T2, T1, T3, T4, T5, T6, T7, T8, TResult> Flip<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> function)
         => (p1, p2, p3, p4, p5, p6, p7, p8) => function(p2, p1, p3, p4, p5, p6, p7, p8);
 
     /// <summary>
-    /// Flips the first two arguments of the function.
+    /// Flips the first two arguments of the action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Action<T2, T1> Flip<T1, T2>(Action<T1, T2> function)
         => (p1, p2) => function(p2, p1);
 
     /// <summary>
-    /// Flips the first two arguments of the function.
+    /// Flips the first two arguments of the action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Action<T2, T1, T3> Flip<T1, T2, T3>(Action<T1, T2, T3> action)
@@ -79,6 +93,7 @@ public static partial class Functional
     /// <summary>
     /// Flips the first two arguments of the action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Action<T2, T1, T3, T4> Flip<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action)
@@ -87,6 +102,7 @@ public static partial class Functional
     /// <summary>
     /// Flips the first two arguments of the action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Action<T2, T1, T3, T4, T5> Flip<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> action)
@@ -95,6 +111,7 @@ public static partial class Functional
     /// <summary>
     /// Flips the first two arguments of the action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Action<T2, T1, T3, T4, T5, T6> Flip<T1, T2, T3, T4, T5, T6>(Action<T1, T2, T3, T4, T5, T6> action)
@@ -103,6 +120,7 @@ public static partial class Functional
     /// <summary>
     /// Flips the first two arguments of the action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Action<T2, T1, T3, T4, T5, T6, T7> Flip<T1, T2, T3, T4, T5, T6, T7>(Action<T1, T2, T3, T4, T5, T6, T7> action)
@@ -111,6 +129,7 @@ public static partial class Functional
     /// <summary>
     /// Flips the first two arguments of the action.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Action<T2, T1, T3, T4, T5, T6, T7, T8> Flip<T1, T2, T3, T4, T5, T6, T7, T8>(Action<T1, T2, T3, T4, T5, T6, T7, T8> action)

--- a/Funcky/Functional/Fn.cs
+++ b/Funcky/Functional/Fn.cs
@@ -1,0 +1,29 @@
+using System.Runtime.CompilerServices;
+
+namespace Funcky;
+
+public static partial class Functional
+{
+    /// <summary>Infers a method group to its natural type i.e. <c>Func&lt;T, ...&gt;</c> and <c>Action&lt;T, ...&gt;</c>.</summary>
+    /// <remarks>This function is identical to <see cref="Identity{T}"/>.
+    /// Prefer the latter for all other cases.</remarks>
+    /// <example>
+    /// Sometimes, the C# compiler is unable to infer a method group's natural type.
+    /// <code><![CDATA[
+    /// var pow = Curry(Math.Pow);
+    /// //        ^^^^^
+    /// // error CS0411: The type arguments for
+    /// // method 'Functional.Curry<...>' cannot
+    /// // be inferred from the usage.
+    /// ]]></code>
+    /// This function can sometimes help with that:
+    /// <code><![CDATA[
+    /// var pow = Curry(Fn(Math.Pow));
+    /// // or:
+    /// var pow = Fn(Math.Pow).Curry();
+    /// ]]></code>
+    /// </example>
+    [Pure]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static T Fn<T>(T value) => value;
+}

--- a/Funcky/Functional/Uncurry.cs
+++ b/Funcky/Functional/Uncurry.cs
@@ -5,6 +5,7 @@ public static partial class Functional
     /// <summary>
     /// Transforms a curried function into a function that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, T2, TResult> Uncurry<T1, T2, TResult>(Func<T1, Func<T2, TResult>> function)
         => (p1, p2) => function(p1)(p2);
@@ -12,6 +13,7 @@ public static partial class Functional
     /// <summary>
     /// Transforms a curried function into a function that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, T2, T3, TResult> Uncurry<T1, T2, T3, TResult>(Func<T1, Func<T2, Func<T3, TResult>>> function)
         => (p1, p2, p3) => function(p1)(p2)(p3);
@@ -19,6 +21,7 @@ public static partial class Functional
     /// <summary>
     /// Transforms a curried function into a function that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, T2, T3, T4, TResult> Uncurry<T1, T2, T3, T4, TResult>(Func<T1, Func<T2, Func<T3, Func<T4, TResult>>>> function)
         => (p1, p2, p3, p4) => function(p1)(p2)(p3)(p4);
@@ -26,6 +29,7 @@ public static partial class Functional
     /// <summary>
     /// Transforms a curried function into a function that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, T2, T3, T4, T5, TResult> Uncurry<T1, T2, T3, T4, T5, TResult>(Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, TResult>>>>> function)
         => (p1, p2, p3, p4, p5) => function(p1)(p2)(p3)(p4)(p5);
@@ -33,6 +37,7 @@ public static partial class Functional
     /// <summary>
     /// Transforms a curried function into a function that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, T2, T3, T4, T5, T6, TResult> Uncurry<T1, T2, T3, T4, T5, T6, TResult>(Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Func<T6, TResult>>>>>> function)
         => (p1, p2, p3, p4, p5, p6) => function(p1)(p2)(p3)(p4)(p5)(p6);
@@ -40,6 +45,7 @@ public static partial class Functional
     /// <summary>
     /// Transforms a curried function into a function that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, T2, T3, T4, T5, T6, T7, TResult> Uncurry<T1, T2, T3, T4, T5, T6, T7, TResult>(Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Func<T6, Func<T7, TResult>>>>>>> function)
         => (p1, p2, p3, p4, p5, p6, p7) => function(p1)(p2)(p3)(p4)(p5)(p6)(p7);
@@ -47,55 +53,63 @@ public static partial class Functional
     /// <summary>
     /// Transforms a curried function into a function that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> Uncurry<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Func<T6, Func<T7, Func<T8, TResult>>>>>>>> function)
         => (p1, p2, p3, p4, p5, p6, p7, p8) => function(p1)(p2)(p3)(p4)(p5)(p6)(p7)(p8);
 
     /// <summary>
-    /// Transforms a curried action into a action that takes multiple arguments.
+    /// Transforms a curried action into an action that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<T1, T2> Uncurry<T1, T2>(Func<T1, Action<T2>> action)
         => (p1, p2) => action(p1)(p2);
 
     /// <summary>
-    /// Transforms a curried action into a action that takes multiple arguments.
+    /// Transforms a curried action into an action that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<T1, T2, T3> Uncurry<T1, T2, T3>(Func<T1, Func<T2, Action<T3>>> action)
         => (p1, p2, p3) => action(p1)(p2)(p3);
 
     /// <summary>
-    /// Transforms a curried action into a action that takes multiple arguments.
+    /// Transforms a curried action into an action that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<T1, T2, T3, T4> Uncurry<T1, T2, T3, T4>(Func<T1, Func<T2, Func<T3, Action<T4>>>> action)
         => (p1, p2, p3, p4) => action(p1)(p2)(p3)(p4);
 
     /// <summary>
-    /// Transforms a curried action into a action that takes multiple arguments.
+    /// Transforms a curried action into an action that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<T1, T2, T3, T4, T5> Uncurry<T1, T2, T3, T4, T5>(Func<T1, Func<T2, Func<T3, Func<T4, Action<T5>>>>> action)
         => (p1, p2, p3, p4, p5) => action(p1)(p2)(p3)(p4)(p5);
 
     /// <summary>
-    /// Transforms a curried action into a action that takes multiple arguments.
+    /// Transforms a curried action into an action that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<T1, T2, T3, T4, T5, T6> Uncurry<T1, T2, T3, T4, T5, T6>(Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Action<T6>>>>>> action)
         => (p1, p2, p3, p4, p5, p6) => action(p1)(p2)(p3)(p4)(p5)(p6);
 
     /// <summary>
-    /// Transforms a curried action into a action that takes multiple arguments.
+    /// Transforms a curried action into an action that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<T1, T2, T3, T4, T5, T6, T7> Uncurry<T1, T2, T3, T4, T5, T6, T7>(Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Func<T6, Action<T7>>>>>>> action)
         => (p1, p2, p3, p4, p5, p6, p7) => action(p1)(p2)(p3)(p4)(p5)(p6)(p7);
 
     /// <summary>
-    /// Transforms a curried action into a action that takes multiple arguments.
+    /// Transforms a curried action into an action that takes multiple arguments.
     /// </summary>
+    /// <seealso cref="Fn{T}"/>
     [Pure]
     public static Action<T1, T2, T3, T4, T5, T6, T7, T8> Uncurry<T1, T2, T3, T4, T5, T6, T7, T8>(Func<T1, Func<T2, Func<T3, Func<T4, Func<T5, Func<T6, Func<T7, Action<T8>>>>>>>> action)
         => (p1, p2, p3, p4, p5, p6, p7, p8) => action(p1)(p2)(p3)(p4)(p5)(p6)(p7)(p8);

--- a/Funcky/PublicAPI.Unshipped.txt
+++ b/Funcky/PublicAPI.Unshipped.txt
@@ -5,3 +5,4 @@ static Funcky.Extensions.JsonSerializerOptionsExtensions.GetTypeInfoOrNone(this 
 static Funcky.Extensions.OrderedDictionaryExtensions.IndexOfOrNone<TKey, TValue>(this System.Collections.Generic.OrderedDictionary<TKey, TValue>! dictionary, TKey key) -> Funcky.Monads.Option<int>
 static Funcky.Extensions.ParseExtensions.ParseIPNetworkOrNone(this string? candidate) -> Funcky.Monads.Option<System.Net.IPNetwork>
 static Funcky.Extensions.ParseExtensions.ParseIPNetworkOrNone(this System.ReadOnlySpan<char> candidate) -> Funcky.Monads.Option<System.Net.IPNetwork>
+static Funcky.Functional.Fn<T>(T value) -> T


### PR DESCRIPTION
I don't know if we already knew this but passing a method group to an identity function helps infer its natural type. This makes using our function and action extensions much more attractive.

To help with the readability I propose an alias for the `Identity` function called `Fn`.

before:
```c#
var pow = Curry(Math.Pow);
//        ^^^^^
// error CS0411: The type arguments for
// method 'Functional.Curry<...>' cannot
// be inferred from the usage.
```

after:
```c#
var pow = Curry(Fn(Math.Pow));
// or
var pow = Fn(Math.Pow).Curry();
// or with Apply:
var expTwo = Apply(Fn(Math.Pow), 2, __);
```