### PR TITLE
Add Funcky.Xunit Packages for xUnit v3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,8 @@
 		<PackageVersion Include="System.Text.Json" Version="5.0.0" />
 		<PackageVersion Include="xunit.assert" Version="[2.9.3, 2.10)" />
 		<PackageVersion Include="xunit.extensibility.core" Version="[2.9.3, 2.10)" />
+		<PackageVersion Include="xunit.v3.assert" Version="[1.0.1, 2)" />
+		<PackageVersion Include="xunit.v3.extensibility.core" Version="[1.0.1, 2)" />
 		<PackageVersion Include="System.Linq.Async" Version="[5.0.0, 7)" />
 	</ItemGroup>
 	<ItemGroup Label="Build Dependencies">
@@ -20,6 +22,7 @@
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
 		<PackageVersion Include="xunit" Version="2.9.3" />
 		<PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
+		<PackageVersion Include="xunit.v3" Version="1.0.1" />
 		<PackageVersion Include="FsCheck.Xunit" Version="3.0.1" />
 		<PackageVersion Include="coverlet.collector" Version="3.1.2" />
 		<PackageVersion Include="Verify.XUnit" Version="16.8.1" />

--- a/Funcky.Xunit.v3.Test/Funcky.Xunit.v3.Test.csproj
+++ b/Funcky.Xunit.v3.Test/Funcky.Xunit.v3.Test.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <LangVersion>preview</LangVersion>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <RootNamespace>Funcky.Xunit.Test</RootNamespace>
+        <OutputType>Exe</OutputType>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit.v3" />
+        <PackageReference Include="xunit.runner.visualstudio" />
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Include="..\Funcky.Xunit.Test\**\*.cs" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Funcky.Xunit.v3\Funcky.Xunit.v3.csproj" />
+    </ItemGroup>
+    <Import Project="..\Analyzers.props" />
+    <Import Project="..\GlobalUsings.props" />
+    <Import Project="..\GlobalUsings.Test.props" />
+</Project>

--- a/Funcky.Xunit.v3/Funcky.Xunit.v3.csproj
+++ b/Funcky.Xunit.v3/Funcky.Xunit.v3.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+        <LangVersion>preview</LangVersion>
+        <Nullable>enable</Nullable>
+        <Description>Package to use Funcky with xUnit v3</Description>
+        <PackageTags>Functional Monad xUnit</PackageTags>
+        <Version>1.0.0</Version>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <RootNamespace>Funcky</RootNamespace>
+    </PropertyGroup>
+    <PropertyGroup>
+        <EnablePackageValidation>true</EnablePackageValidation>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+        <DefineConstants>$(DefineConstants);STACK_TRACE_HIDDEN_SUPPORTED</DefineConstants>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Include="..\Funcky.Xunit\**\*.cs" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="PolySharp" PrivateAssets="all" />
+        <PackageReference Include="xunit.v3.assert" />
+        <PackageReference Include="xunit.v3.extensibility.core" />
+        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net6.0'" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="../Funcky/Funcky.csproj" />
+    </ItemGroup>
+    <Import Project="..\Analyzers.props" />
+    <Import Project="..\GlobalUsings.props" />
+    <Import Project="..\SemanticVersioning.targets" />
+</Project>

--- a/Funcky.Xunit.v3/PublicAPI.Shipped.txt
+++ b/Funcky.Xunit.v3/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/Funcky.Xunit.v3/PublicAPI.Unshipped.txt
+++ b/Funcky.Xunit.v3/PublicAPI.Unshipped.txt
@@ -1,0 +1,34 @@
+#nullable enable
+static Funcky.FunctionalAssert.Some<TItem>(TItem expectedValue, Funcky.Monads.Option<TItem> option) -> void
+static Funcky.FunctionalAssert.Some<TItem>(Funcky.Monads.Option<TItem> option) -> TItem
+static Funcky.FunctionalAssert.Right<TLeft, TRight>(TRight expectedRight, Funcky.Monads.Either<TLeft, TRight> either) -> void
+static Funcky.FunctionalAssert.Right<TLeft, TRight>(Funcky.Monads.Either<TLeft, TRight> either) -> TRight
+static Funcky.FunctionalAssert.Ok<TValidResult>(TValidResult expectedResult, Funcky.Monads.Result<TValidResult> result) -> void
+static Funcky.FunctionalAssert.Ok<TValidResult>(Funcky.Monads.Result<TValidResult> result) -> TValidResult
+static Funcky.FunctionalAssert.None<TItem>(Funcky.Monads.Option<TItem> option) -> void
+static Funcky.FunctionalAssert.Left<TLeft, TRight>(TLeft expectedLeft, Funcky.Monads.Either<TLeft, TRight> either) -> void
+static Funcky.FunctionalAssert.Left<TLeft, TRight>(Funcky.Monads.Either<TLeft, TRight> either) -> TLeft
+static Funcky.FunctionalAssert.Error<TValidResult>(Funcky.Monads.Result<TValidResult> result) -> System.Exception!
+static Funcky.Extensions.ToTheoryDataExtension.ToTheoryData<T1>(this System.Collections.Generic.IEnumerable<T1>! source) -> Xunit.TheoryData<T1>!
+static Funcky.Extensions.ToTheoryDataExtension.ToTheoryData<T1>(this System.Collections.Generic.IEnumerable<System.ValueTuple<T1>>! source) -> Xunit.TheoryData<T1>!
+static Funcky.Extensions.ToTheoryDataExtension.ToTheoryData<T1>(this System.Collections.Generic.IEnumerable<System.Tuple<T1>!>! source) -> Xunit.TheoryData<T1>!
+static Funcky.Extensions.ToTheoryDataExtension.ToTheoryData<T1, T2>(this System.Collections.Generic.IEnumerable<System.Tuple<T1, T2>!>! source) -> Xunit.TheoryData<T1, T2>!
+static Funcky.Extensions.ToTheoryDataExtension.ToTheoryData<T1, T2>(this System.Collections.Generic.IEnumerable<(T1 Item1, T2 Item2)>! source) -> Xunit.TheoryData<T1, T2>!
+static Funcky.Extensions.ToTheoryDataExtension.ToTheoryData<T1, T2, T3>(this System.Collections.Generic.IEnumerable<System.Tuple<T1, T2, T3>!>! source) -> Xunit.TheoryData<T1, T2, T3>!
+static Funcky.Extensions.ToTheoryDataExtension.ToTheoryData<T1, T2, T3>(this System.Collections.Generic.IEnumerable<(T1 Item1, T2 Item2, T3 Item3)>! source) -> Xunit.TheoryData<T1, T2, T3>!
+static Funcky.Extensions.ToTheoryDataExtension.ToTheoryData<T1, T2, T3, T4>(this System.Collections.Generic.IEnumerable<System.Tuple<T1, T2, T3, T4>!>! source) -> Xunit.TheoryData<T1, T2, T3, T4>!
+static Funcky.Extensions.ToTheoryDataExtension.ToTheoryData<T1, T2, T3, T4>(this System.Collections.Generic.IEnumerable<(T1 Item1, T2 Item2, T3 Item3, T4 Item4)>! source) -> Xunit.TheoryData<T1, T2, T3, T4>!
+static Funcky.Extensions.ToTheoryDataExtension.ToTheoryData<T1, T2, T3, T4, T5>(this System.Collections.Generic.IEnumerable<System.Tuple<T1, T2, T3, T4, T5>!>! source) -> Xunit.TheoryData<T1, T2, T3, T4, T5>!
+static Funcky.Extensions.ToTheoryDataExtension.ToTheoryData<T1, T2, T3, T4, T5>(this System.Collections.Generic.IEnumerable<(T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5)>! source) -> Xunit.TheoryData<T1, T2, T3, T4, T5>!
+static Funcky.Extensions.ToTheoryDataExtension.ToTheoryData<T1, T2, T3, T4, T5, T6>(this System.Collections.Generic.IEnumerable<System.Tuple<T1, T2, T3, T4, T5, T6>!>! source) -> Xunit.TheoryData<T1, T2, T3, T4, T5, T6>!
+static Funcky.Extensions.ToTheoryDataExtension.ToTheoryData<T1, T2, T3, T4, T5, T6>(this System.Collections.Generic.IEnumerable<(T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5, T6 Item6)>! source) -> Xunit.TheoryData<T1, T2, T3, T4, T5, T6>!
+static Funcky.Extensions.ToTheoryDataExtension.ToTheoryData<T1, T2, T3, T4, T5, T6, T7>(this System.Collections.Generic.IEnumerable<System.Tuple<T1, T2, T3, T4, T5, T6, T7>!>! source) -> Xunit.TheoryData<T1, T2, T3, T4, T5, T6, T7>!
+static Funcky.Extensions.ToTheoryDataExtension.ToTheoryData<T1, T2, T3, T4, T5, T6, T7>(this System.Collections.Generic.IEnumerable<(T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5, T6 Item6, T7 Item7)>! source) -> Xunit.TheoryData<T1, T2, T3, T4, T5, T6, T7>!
+static Funcky.Extensions.ToTheoryDataExtension.ToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8>(this System.Collections.Generic.IEnumerable<System.Tuple<T1, T2, T3, T4, T5, T6, T7, T8>!>! source) -> Xunit.TheoryData<T1, T2, T3, T4, T5, T6, T7, T8>!
+static Funcky.Extensions.ToTheoryDataExtension.ToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8>(this System.Collections.Generic.IEnumerable<(T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5, T6 Item6, T7 Item7, T8 Item8)>! source) -> Xunit.TheoryData<T1, T2, T3, T4, T5, T6, T7, T8>!
+static Funcky.Extensions.ToTheoryDataExtension.ToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this System.Collections.Generic.IEnumerable<System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9>!>!>! source) -> Xunit.TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9>!
+static Funcky.Extensions.ToTheoryDataExtension.ToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this System.Collections.Generic.IEnumerable<(T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5, T6 Item6, T7 Item7, T8 Item8, T9 Item9)>! source) -> Xunit.TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9>!
+static Funcky.Extensions.ToTheoryDataExtension.ToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this System.Collections.Generic.IEnumerable<System.Tuple<T1, T2, T3, T4, T5, T6, T7, System.Tuple<T8, T9, T10>!>!>! source) -> Xunit.TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>!
+static Funcky.Extensions.ToTheoryDataExtension.ToTheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this System.Collections.Generic.IEnumerable<(T1 Item1, T2 Item2, T3 Item3, T4 Item4, T5 Item5, T6 Item6, T7 Item7, T8 Item8, T9 Item9, T10 Item10)>! source) -> Xunit.TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>!
+Funcky.FunctionalAssert
+Funcky.Extensions.ToTheoryDataExtension

--- a/Funcky.sln
+++ b/Funcky.sln
@@ -65,6 +65,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Funcky.TrimmingTest", "Func
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Funcky.BuiltinAnalyzers.CodeFixes", "Funcky.Analyzers\Funcky.BuiltinAnalyzers.CodeFixes\Funcky.BuiltinAnalyzers.CodeFixes.csproj", "{82BAB120-6F95-4B5A-83EA-C7BCFB1C03C2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Funcky.Xunit.v3", "Funcky.Xunit.v3\Funcky.Xunit.v3.csproj", "{2EA64974-E4A4-416E-9E35-5744B5244EBB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Funcky.Xunit.v3.Test", "Funcky.Xunit.v3.Test\Funcky.Xunit.v3.Test.csproj", "{D9E9CC4B-34F9-4195-B21C-B11AD4DA63F3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -143,6 +147,14 @@ Global
 		{82BAB120-6F95-4B5A-83EA-C7BCFB1C03C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{82BAB120-6F95-4B5A-83EA-C7BCFB1C03C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{82BAB120-6F95-4B5A-83EA-C7BCFB1C03C2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2EA64974-E4A4-416E-9E35-5744B5244EBB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2EA64974-E4A4-416E-9E35-5744B5244EBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2EA64974-E4A4-416E-9E35-5744B5244EBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2EA64974-E4A4-416E-9E35-5744B5244EBB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9E9CC4B-34F9-4195-B21C-B11AD4DA63F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9E9CC4B-34F9-4195-B21C-B11AD4DA63F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9E9CC4B-34F9-4195-B21C-B11AD4DA63F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9E9CC4B-34F9-4195-B21C-B11AD4DA63F3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
xUnit v3 is finally here 🎉 

We could either:
* Update `Funcky.Xunit` to xUnit v3. This means that we force ourselves and our consumers to update to xUnit v3 right now (a lot of third-party libraries such as `FsCheck.Xunit` are not yet updated to v3)
* Take the same approach that xUnit itself uses i.e. appending `.v3` to the packages. This is what this PR does.

Do we still want to include `ToTheoryData` in v3? The new theory data is much more powerful:
  * Collection expressions work for `TheoryData`:
    ```csharp
    public static TheoryData<int, string> IntegersAndStringRepr => [
        (10, "10"),
        (20, "20"),
    ];
    ```
  * Enumerables can easily be converted to `TheoryData` by passing it to its constructor:
    ```csharp
 	public static TheoryData<int, string> IntegersAndStringRepr => new(
        Enumerable.Range(0, count: 5)
            .Select(n => n * 10)
            .Select(n => (n, n.ToString())));
    ```
