### PR TITLE
Add RemoveOrNone to Dictionary extensions

### DIFF
--- a/FrameworkFeatureConstants.props
+++ b/FrameworkFeatureConstants.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))">
-		<DefineConstants>$(DefineConstants);INDEX_OF_CHAR_COMPARISONTYPE_SUPPORTED;TIMESPAN_MULTIPLY_SUPPORTED;SPLIT_ACCEPTS_STRING_SEPARATOR;LAZY_RETURN_CONSTRUCTOR;QUEUE_TRY_OVERLOADS;OPTIMIZED_ELEMENT_AT;RANGE_SUPPORTED;READ_ONLY_SPAN_SUPPORTED;INDEX_TYPE;JOIN_TO_STRING_CHAR_SEPARATOR</DefineConstants>
+		<DefineConstants>$(DefineConstants);INDEX_OF_CHAR_COMPARISONTYPE_SUPPORTED;TIMESPAN_MULTIPLY_SUPPORTED;SPLIT_ACCEPTS_STRING_SEPARATOR;LAZY_RETURN_CONSTRUCTOR;QUEUE_TRY_OVERLOADS;OPTIMIZED_ELEMENT_AT;RANGE_SUPPORTED;READ_ONLY_SPAN_SUPPORTED;INDEX_TYPE;JOIN_TO_STRING_CHAR_SEPARATOR;REMOVE_EXTENSION</DefineConstants>
 	</PropertyGroup>
 	<PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netcoreapp3.0'))">
 		<DefineConstants>$(DefineConstants);SYSTEM_INDEX_SUPPORTED;IP_END_POINT_TRY_PARSE_SUPPORTED</DefineConstants>

--- a/Funcky.Test/Extensions/DictionaryExtensionTest.cs
+++ b/Funcky.Test/Extensions/DictionaryExtensionTest.cs
@@ -22,4 +22,28 @@ public sealed class DictionaryExtensionTest
         var dictionary = new Dictionary<string, string> { ["some"] = "value" };
         _ = dictionary.GetValueOrNone("some");
     }
+
+#if REMOVE_EXTENSION
+    [Fact]
+    public void RemoveOrNoneOfAnExistingItemRemovesItemFromDictionaryAndReturnsTheValue()
+    {
+        IDictionary<string, string> dictionary = new Dictionary<string, string> { ["some"] = "value" };
+
+        var value = dictionary.RemoveOrNone("some");
+
+        Assert.Empty(dictionary);
+        FunctionalAssert.Some("value", value);
+    }
+
+    [Fact]
+    public void RemoveOrNoneOfANonExistingItemReturnsNoneAndLeavesTheDictionaryUnchanegd()
+    {
+        IDictionary<string, string> dictionary = new Dictionary<string, string> { ["some"] = "value" };
+
+        var value = dictionary.RemoveOrNone("none");
+
+        Assert.NotEmpty(dictionary);
+        FunctionalAssert.None(value);
+    }
+#endif
 }

--- a/Funcky.sln
+++ b/Funcky.sln
@@ -17,6 +17,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build Config", "Build Config", "{DD8F8450-BE23-4D6B-9C5C-7AED0ABB7531}"
 	ProjectSection(SolutionItems) = preProject
+		Analyzers.props = Analyzers.props
+		Funcky\CompatibilitySuppressions.xml = Funcky\CompatibilitySuppressions.xml
 		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
 		FrameworkFeatureConstants.props = FrameworkFeatureConstants.props
@@ -24,9 +26,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build Config", "Build Confi
 		GlobalUsings.props = GlobalUsings.props
 		GlobalUsings.Test.props = GlobalUsings.Test.props
 		NuGet.config = NuGet.config
-		typos.toml = typos.toml
-		Analyzers.props = Analyzers.props
 		SemanticVersioning.targets = SemanticVersioning.targets
+		typos.toml = typos.toml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Funcky.Xunit", "Funcky.Xunit\Funcky.Xunit.csproj", "{F2E98B0D-CC17-4576-89DE-065FF475BE6E}"

--- a/Funcky/CompatibilitySuppressions.xml
+++ b/Funcky/CompatibilitySuppressions.xml
@@ -19,4 +19,10 @@
     <Left>lib/netstandard2.1/Funcky.dll</Left>
     <Right>lib/netcoreapp3.1/Funcky.dll</Right>
   </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0021</DiagnosticId>
+    <Target>M:Funcky.Extensions.DictionaryExtensions.RemoveOrNone``2(System.Collections.Generic.IDictionary{``0,``1},``0)``0:notnull</Target>
+    <Left>lib/netstandard2.1/Funcky.dll</Left>
+    <Right>lib/netcoreapp3.1/Funcky.dll</Right>
+  </Suppression>
 </Suppressions>

--- a/Funcky/Extensions/DictionaryExtensions.cs
+++ b/Funcky/Extensions/DictionaryExtensions.cs
@@ -28,4 +28,17 @@ public static class DictionaryExtensions
         => dictionary.TryGetValue(readOnlyKey, out var result)
             ? result
             : Option<TValue>.None;
+
+#if REMOVE_EXTENSION
+    public static Option<TValue> RemoveOrNone<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
+#if NETCOREAPP3_1
+        // TKey was constraint to notnull when nullability annotations were originally added. It was later dropped again.
+        // See: https://github.com/dotnet/runtime/issues/31401
+        where TKey : notnull
+#endif
+        where TValue : notnull
+        => dictionary.Remove(key, out var result)
+            ? result
+            : Option<TValue>.None;
+#endif
 }

--- a/Funcky/PublicAPI.Unshipped.txt
+++ b/Funcky/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 Funcky.Extensions.JsonSerializerOptionsExtensions
 Funcky.Extensions.OrderedDictionaryExtensions
+static Funcky.Extensions.DictionaryExtensions.RemoveOrNone<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue>! dictionary, TKey key) -> Funcky.Monads.Option<TValue>
 static Funcky.Extensions.FuncExtensions.Apply<T1, T2, T3, T4, T5, TResult>(this System.Func<T1, T2, T3, T4, T5, TResult>! func, Funcky.Unit p1, Funcky.Unit p2, Funcky.Unit p3, Funcky.Unit p4, T5 p5) -> System.Func<T1, T2, T3, T4, TResult>!
 static Funcky.Extensions.FuncExtensions.Apply<T1, T2, T3, T4, T5, TResult>(this System.Func<T1, T2, T3, T4, T5, TResult>! func, Funcky.Unit p1, Funcky.Unit p2, Funcky.Unit p3, T4 p4, Funcky.Unit p5) -> System.Func<T1, T2, T3, T5, TResult>!
 static Funcky.Extensions.FuncExtensions.Apply<T1, T2, T3, T4, T5, TResult>(this System.Func<T1, T2, T3, T4, T5, TResult>! func, Funcky.Unit p1, Funcky.Unit p2, Funcky.Unit p3, T4 p4, T5 p5) -> System.Func<T1, T2, T3, TResult>!


### PR DESCRIPTION
The Remove is an Extension on the `IDictionary` interface and has an out-parameter returning the removed Item.

Even though it has a side effect it maps perfectly to the Try* Pattern.