### PR TITLE
Publish nightly packages for all projects

### DIFF
--- a/.github/workflows/publish-nightly-package.yml
+++ b/.github/workflows/publish-nightly-package.yml
@@ -13,6 +13,6 @@ jobs:
     - uses: actions/setup-dotnet@v4
       name: Install Current .NET SDK
     - name: Pack Packages
-      run: dotnet pack Funcky/Funcky.csproj --output nupkg --version-suffix "nightly.$(git rev-parse --short "${{github.sha}}")"
-    - name: Push Package
+      run: dotnet pack --output nupkg --version-suffix "nightly.$(git rev-parse --short "${{github.sha}}")"
+    - name: Push Packages
       run: dotnet nuget push --source https://nuget.pkg.github.com/polyadic/index.json --api-key ${{secrets.GITHUB_TOKEN}} nupkg/Funcky.*.nupkg

--- a/Funcky.TrimmingTest/Funcky.TrimmingTest.csproj
+++ b/Funcky.TrimmingTest/Funcky.TrimmingTest.csproj
@@ -6,6 +6,7 @@
         <Nullable>enable</Nullable>
         <PublishTrimmed Condition="'$(FunckyTestAot)' != 'true'">true</PublishTrimmed>
         <PublishAot Condition="'$(FunckyTestAot)' == 'true'">true</PublishAot>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>
         <!-- Analyze the whole library, even if attributed with "IsTrimmable" -->

--- a/Funcky.Xunit.v3/Funcky.Xunit.v3.csproj
+++ b/Funcky.Xunit.v3/Funcky.Xunit.v3.csproj
@@ -5,7 +5,7 @@
         <Nullable>enable</Nullable>
         <Description>Package to use Funcky with xUnit v3</Description>
         <PackageTags>Functional Monad xUnit</PackageTags>
-        <Version>1.0.0</Version>
+        <VersionPrefix>1.0.0</VersionPrefix>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <RootNamespace>Funcky</RootNamespace>


### PR DESCRIPTION
We currently only publish nightlies for Funcky but not the other packages in the solution.