### PR TITLE
Use version prefix for analyzers package

### DIFF
--- a/Funcky.Analyzers/Funcky.Analyzers.Package/Funcky.Analyzers.Package.csproj
+++ b/Funcky.Analyzers/Funcky.Analyzers.Package/Funcky.Analyzers.Package.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
     <PropertyGroup Label="NuGet Metadata">
         <PackageId>Funcky.Analyzers</PackageId>
-        <PackageVersion>1.4.0</PackageVersion>
+        <PackageVersionPrefix>1.4.0</PackageVersionPrefix>
         <Description>Analyzers to guide to the correct usage of Funcky.</Description>
         <PackageTags>funcky, analyzers, roslyn</PackageTags>
         <DevelopmentDependency>true</DevelopmentDependency>


### PR DESCRIPTION
This is so that the nightly publish can use `--version-suffix` to add the `nightly.COMMIT_SHA` suffix