### PR TITLE
Fix some rough edges of Roslyn multi-targeting

### DIFF
--- a/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/Funcky.Analyzers.CodeFixes.Roslyn4.0.csproj
+++ b/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/Funcky.Analyzers.CodeFixes.Roslyn4.0.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <RoslynApiVersion>4.0.1</RoslynApiVersion>
+        <AnalyzerRoslynVersion>4.0.1</AnalyzerRoslynVersion>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\Funcky.Analyzers\Funcky.Analyzers.Roslyn4.0.csproj" PrivateAssets="all" />

--- a/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/Funcky.Analyzers.CodeFixes.targets
+++ b/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/Funcky.Analyzers.CodeFixes.targets
@@ -2,12 +2,16 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<IsPackable>false</IsPackable>
-		<RootNamespace>Funcky.Analyzers</RootNamespace>
-		<AssemblyName>Funcky.Analyzers.CodeFixes</AssemblyName>
 		<LangVersion>preview</LangVersion>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<AnalysisLevel>5</AnalysisLevel>
+	</PropertyGroup>
+	<PropertyGroup>
+		<!-- These are properties that are usually default to the project name, but since
+		     we have a project per roslyn version, we need to be explicit. -->
+		<AssemblyName>Funcky.Analyzers.CodeFixes</AssemblyName>
+		<RootNamespace>Funcky.Analyzers</RootNamespace>
 	</PropertyGroup>
 	<PropertyGroup>
 		<AnalyzerLanguage>cs</AnalyzerLanguage>

--- a/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/Funcky.Analyzers.CodeFixes.targets
+++ b/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/Funcky.Analyzers.CodeFixes.targets
@@ -15,11 +15,10 @@
 	</PropertyGroup>
 	<PropertyGroup>
 		<AnalyzerLanguage>cs</AnalyzerLanguage>
-		<RoslynApiVersion Condition="'$(RoslynApiVersion)' == '' And '$(AnalyzerRoslynVersion)' != ''">$(AnalyzerRoslynVersion)</RoslynApiVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="PolySharp" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" VersionOverride="$(RoslynApiVersion)" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" VersionOverride="$(AnalyzerRoslynVersion)" PrivateAssets="all" />
 	</ItemGroup>
 	<ItemGroup>
 		<Compile Update="CodeFixResources.Designer.cs" DesignTime="True" AutoGen="True" DependentUpon="CodeFixResources.resx" />

--- a/Funcky.Analyzers/Funcky.Analyzers.Package/Funcky.Analyzers.Package.csproj
+++ b/Funcky.Analyzers/Funcky.Analyzers.Package/Funcky.Analyzers.Package.csproj
@@ -25,6 +25,7 @@
     </ItemGroup>
     <ItemGroup>
         <None Update="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="" />
+        <None Update="buildTransitive\$(PackageId).targets" Pack="true" PackagePath="%(Identity)" />
     </ItemGroup>
     <!-- Adapted from https://github.com/dotnet/runtime/blob/4bd597ffde128555b4ff017e87c60adc2fedd178/eng/packaging.targets#L136 -->
     <PropertyGroup>

--- a/Funcky.Analyzers/Funcky.Analyzers.Package/Packing.targets
+++ b/Funcky.Analyzers/Funcky.Analyzers.Package/Packing.targets
@@ -7,6 +7,9 @@
 	<Target Name="GetAnalyzerPackFiles"
 			DependsOnTargets="$(GenerateNuspecDependsOn)"
 			Returns="@(_AnalyzerPackFile)">
+		<Error Text="Project is missing the 'AnalyzerRoslynVersion' property" Condition="'$(AnalyzerRoslynVersion)' == ''" />
+		<Error Text="Project is missing the 'AnalyzerLanguage' property" Condition="'$(AnalyzerLanguage)' == ''" />
+
 		<PropertyGroup>
 			<_analyzerPath>analyzers/dotnet</_analyzerPath>
 			<_analyzerRoslynVersion Condition="'$(AnalyzerRoslynVersion)' != ''">$([System.Version]::Parse($(AnalyzerRoslynVersion)).Major).$([System.Version]::Parse($(AnalyzerRoslynVersion)).Minor)</_analyzerRoslynVersion>

--- a/Funcky.Analyzers/Funcky.Analyzers.Package/buildTransitive/Funcky.Analyzers.targets
+++ b/Funcky.Analyzers/Funcky.Analyzers.Package/buildTransitive/Funcky.Analyzers.targets
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Target Name="_Funcky_Analyzers_WarnAboutUnsupportedRoslynVersion"
+			Condition="'$(SupportsRoslynComponentVersioning)' != 'true'"
+			AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets">
+		<Warning Code="λ.BUILD.0001"
+				 Text="Funcky.Analyzers requires at least Roslyn 4.x i.e. Visual Studio 2022 / .NET 6.0" />
+		<ItemGroup>
+			<Analyzer Remove="@(Analyzer->WithMetadataValue('NuGetPackageId', 'Funcky.Analyzers'))" />
+		</ItemGroup>
+	</Target>
+</Project>

--- a/Funcky.Analyzers/Funcky.Analyzers/Funcky.Analyzers.Roslyn4.0.csproj
+++ b/Funcky.Analyzers/Funcky.Analyzers/Funcky.Analyzers.Roslyn4.0.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <RoslynApiVersion>4.0.1</RoslynApiVersion>
+        <AnalyzerRoslynVersion>4.0.1</AnalyzerRoslynVersion>
     </PropertyGroup>
     <Import Project="Funcky.Analyzers.targets" />
 </Project>

--- a/Funcky.Analyzers/Funcky.Analyzers/Funcky.Analyzers.targets
+++ b/Funcky.Analyzers/Funcky.Analyzers/Funcky.Analyzers.targets
@@ -5,12 +5,17 @@
 		<IsPackable>false</IsPackable>
 		<!-- Avoid ID conflicts with the package project. -->
 		<PackageId>*$(MSBuildProjectFile)*</PackageId>
-		<AssemblyName>Funcky.Analyzers</AssemblyName>
 		<LangVersion>preview</LangVersion>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<AnalysisLevel>5</AnalysisLevel>
 		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+	</PropertyGroup>
+	<PropertyGroup>
+		<!-- These are properties that are usually default to the project name, but since
+		     we have a project per roslyn version, we need to be explicit. -->
+		<AssemblyName>Funcky.Analyzers</AssemblyName>
+		<RootNamespace>Funcky.Analyzers</RootNamespace>
 	</PropertyGroup>
 	<PropertyGroup>
 		<AnalyzerLanguage>cs</AnalyzerLanguage>

--- a/Funcky.Analyzers/Funcky.Analyzers/Funcky.Analyzers.targets
+++ b/Funcky.Analyzers/Funcky.Analyzers/Funcky.Analyzers.targets
@@ -19,12 +19,11 @@
 	</PropertyGroup>
 	<PropertyGroup>
 		<AnalyzerLanguage>cs</AnalyzerLanguage>
-		<RoslynApiVersion Condition="'$(RoslynApiVersion)' == '' And '$(AnalyzerRoslynVersion)' != ''">$(AnalyzerRoslynVersion)</RoslynApiVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="PolySharp" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="$(RoslynApiVersion)" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="$(AnalyzerRoslynVersion)" PrivateAssets="all" />
 	</ItemGroup>
 	<ItemGroup>
 		<Compile Update="Resources.Designer.cs">

--- a/Funcky.Analyzers/readme.md
+++ b/Funcky.Analyzers/readme.md
@@ -22,14 +22,29 @@ This means that we ship multiple copies of the analyzer assembly in the followin
 ```
 ╰─ analyzers
    ╰─ dotnet
-      ├─ cs
-      │  ├─ Funcky.Analyzers.dll
-      │  ╰─ ...
+      ├─ roslyn4.0
+      │   ╰─ cs
+      │      ├─ Funcky.Analyzers.dll
+      │      ╰─ ...
       ╰─ roslyn4.12
          ╰─ cs
             ├─ Funcky.Analyzers.dll
             ╰─ ...
 ```
+
+From the different versions, the highest compatible version is picked.
+
+### Remarks
+* SDKs that don't support multi-targeting load analyzers recursively,
+  even inside the "versioned" `roslyn*` directories.
+    * The `System.Text.Json` package fixes this by shipping a `.targets` file with their packages that
+      catches this case by checking for the `SupportsRoslynComponentVersioning` property
+      and manually removing discovered analyzers that are incompatible.
+    * Our analyzers require at least Roslyn 4.0 / .NET 6.0 (which is the version that introduced multi-targeting)
+      so we fix this by shipping a `.targets` file that removes all our analyzers and warns the user.
+* SDKs versions that support multi-targeting also load analyzers
+  that are not in a `roslyn*` directory, so to avoid loading analyzers twice
+  all analyzers need to be inside a `roslyn*` directory.
 
 ## Roslyn Version Compatibility
 There are three documents that help figure out what version of Roslyn to target:


### PR DESCRIPTION
Follow-up to #834

I learned some new things while testing the analyzer package with both an SDK that supports multi-targeting and one that doesn't:

* The name for embedded resources is derived from the `RootNamespace` property which in turn is derived from the project name, **not** the `AssemblyName` as I had previously thought. This means that the resources could not be loaded for one of the analyzer versions :/
* SDKs *with* support for multi-targeting load analyzers outside the `roslyn*` directory. Luckily the minimum Roslyn version that we support (4.0) was shipped with an SDK that already supports multi-targeting, so now we now put that analyzer version inside `roslyn4.0`.
* SDKs *without* support for multi-targeting load analyzers recursively (even inside `roslyn*` directories) which causes lots of noisy errors. To improve the situation in that case, I have included a `.targets` file that removes the analyzers and warns the user. \
  ![image](https://github.com/user-attachments/assets/0666ebd0-0727-467e-885e-7ce5d9aca56f)
