### PR TITLE
Add analyzer for `FunctionalAssert` usage

### DIFF
--- a/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/AlternativeMonad/MatchToOrElseCodeFix.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/AlternativeMonad/MatchToOrElseCodeFix.cs
@@ -26,8 +26,7 @@ public sealed class MatchToOrElseCodeFix : CodeFixProvider
         foreach (var diagnostic in context.Diagnostics)
         {
             if (syntaxRoot?.FindInvocationExpression(context.Span) is { Expression: MemberAccessExpressionSyntax memberAccessExpression } invocation
-                && diagnostic.Properties.TryGetValue(PreservedArgumentIndexProperty, out var errorStateArgumentIndexString)
-                && int.TryParse(errorStateArgumentIndexString, out var noneArgumentIndex))
+                && diagnostic.TryGetIntProperty(PreservedArgumentIndexProperty, out var noneArgumentIndex))
             {
                 context.RegisterCodeFix(new GetOrElseCodeFixAction(context.Document, invocation, memberAccessExpression, noneArgumentIndex, DiagnosticIdToMethodName(diagnostic.Id)), diagnostic);
             }

--- a/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/DiagnosticExtensions.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/DiagnosticExtensions.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+
+namespace Funcky.Analyzers;
+
+internal static class DiagnosticExtensions
+{
+    // No static interfaces or IParsable<T> in .NET Standard 2.0...
+    private delegate bool TryParseDelegate<T>(string? s, [NotNullWhen(true)] out T? value);
+
+    public static bool TryGetIntProperty(this Diagnostic diagnostic, string propertyName, out int value)
+        => TryGetProperty(diagnostic, propertyName, int.TryParse, out value);
+
+    private static bool TryGetProperty<T>(this Diagnostic diagnostic, string propertyName, TryParseDelegate<T> parser, [NotNullWhen(true)] out T? value)
+    {
+        value = default;
+        return diagnostic.Properties.TryGetValue(propertyName, out var stringValue) && parser(stringValue, out value);
+    }
+}

--- a/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/EnumerableRepeatNeverCodeFix.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/EnumerableRepeatNeverCodeFix.cs
@@ -30,8 +30,7 @@ public sealed class EnumerableRepeatNeverCodeFix : CodeFixProvider
         var diagnosticSpan = diagnostic.Location.SourceSpan;
 
         if (root?.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().First() is { } declaration
-            && diagnostic.Properties.TryGetValue(ValueParameterIndexProperty, out var valueParameterIndexProperty)
-            && int.TryParse(valueParameterIndexProperty, out var valueParameterIndex))
+            && diagnostic.TryGetIntProperty(ValueParameterIndexProperty, out var valueParameterIndex))
         {
             context.RegisterCodeFix(new ToEnumerableEmptyCodeAction(context.Document, declaration, valueParameterIndex), diagnostic);
         }

--- a/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/EnumerableRepeatOnceCodeFix.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/EnumerableRepeatOnceCodeFix.cs
@@ -31,8 +31,7 @@ public sealed class EnumerableRepeatOnceCodeFix : CodeFixProvider
         var diagnosticSpan = diagnostic.Location.SourceSpan;
 
         if (root?.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().First() is { } declaration
-            && diagnostic.Properties.TryGetValue(ValueParameterIndexProperty, out var valueParameterIndexProperty)
-            && int.TryParse(valueParameterIndexProperty, out var valueParameterIndex))
+            && diagnostic.TryGetIntProperty(ValueParameterIndexProperty, out var valueParameterIndex))
         {
             context.RegisterCodeFix(new ToSequenceReturnCodeAction(context.Document, declaration, valueParameterIndex), diagnostic);
         }

--- a/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/FunctionalAssertFix.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/FunctionalAssertFix.cs
@@ -1,0 +1,78 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Funcky.Analyzers.FunctionalAssert.FunctionalAssertAnalyzer;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Funcky.Analyzers;
+
+[Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AddArgumentNameCodeFix))]
+public sealed class FunctionalAssertFix : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds
+        => ImmutableArray.Create(PreferFunctionalAssert.Id);
+
+    public override FixAllProvider GetFixAllProvider()
+        => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        if (await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false) is { } root
+            && await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false) is { } semanticModel)
+        {
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                if (diagnostic.Properties.TryGetValue(ExpectedArgumentIndex, out var expectedArgumentIndexString)
+                    && int.TryParse(expectedArgumentIndexString, out var expectedArgumentIndex)
+                    && diagnostic.Properties.TryGetValue(ActualArgumentIndex, out var actualArgumentIndexString)
+                    && int.TryParse(actualArgumentIndexString, out var actualArgumentIndex)
+                    && root.FindNode(diagnostic.Location.SourceSpan).FirstAncestorOrSelf<InvocationExpressionSyntax>() is { } invocationSyntax
+                    && invocationSyntax.ArgumentList.Arguments[expectedArgumentIndex] is var expectedArgumentSyntax
+                    && invocationSyntax.ArgumentList.Arguments[actualArgumentIndex] is var actualArgumentSyntax
+                    && actualArgumentSyntax.Expression is InvocationExpressionSyntax innerInvocationSyntax)
+                {
+                    context.RegisterCodeFix(CreateFix(context, new FixInputs(invocationSyntax, expectedArgumentSyntax, actualArgumentSyntax, innerInvocationSyntax)), diagnostic);
+                }
+            }
+        }
+    }
+
+    private static CodeAction CreateFix(CodeFixContext context, FixInputs inputs)
+        => CodeAction.Create(
+            title: "Simplify assertion",
+            SimplifyAssertionAsync(context.Document, inputs),
+            nameof(AddArgumentNameCodeFix));
+
+    private static Func<CancellationToken, Task<Document>> SimplifyAssertionAsync(Document document, FixInputs inputs)
+        => async cancellationToken
+            => await document.GetSyntaxRootAsync(cancellationToken) is { } syntaxRoot
+                ? document.WithSyntaxRoot(syntaxRoot.ReplaceNode(inputs.InvocationSyntax, SimplifyAssertion(inputs)))
+                : document;
+
+    private static InvocationExpressionSyntax SimplifyAssertion(FixInputs inputs)
+        => InvocationExpression(inputs.InnerInvocationSyntax.Expression)
+            .WithArgumentList(FunctionalAssertArgumentList(inputs))
+            .WithTriviaFrom(inputs.InvocationSyntax);
+
+    private static ArgumentListSyntax FunctionalAssertArgumentList(FixInputs inputs)
+    {
+        var assertArgumentList = inputs.InvocationSyntax.ArgumentList;
+        return assertArgumentList.WithArguments(SeparatedList(FunctionalAssertArguments(inputs), assertArgumentList.Arguments.GetSeparators()));
+    }
+
+    private static IEnumerable<ArgumentSyntax> FunctionalAssertArguments(FixInputs inputs)
+        => [
+            Argument(inputs.ExpectedArgumentSyntax.Expression).WithTriviaFrom(inputs.ExpectedArgumentSyntax),
+            Argument(inputs.InnerInvocationSyntax.ArgumentList.Arguments[0].Expression).WithTriviaFrom(inputs.ActualArgumentSyntax),
+        ];
+
+    private sealed record FixInputs(
+        InvocationExpressionSyntax InvocationSyntax,
+        ArgumentSyntax ExpectedArgumentSyntax,
+        ArgumentSyntax ActualArgumentSyntax,
+        InvocationExpressionSyntax InnerInvocationSyntax);
+}

--- a/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/FunctionalAssertFix.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers.CodeFixes/FunctionalAssertFix.cs
@@ -26,10 +26,8 @@ public sealed class FunctionalAssertFix : CodeFixProvider
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (diagnostic.Properties.TryGetValue(ExpectedArgumentIndex, out var expectedArgumentIndexString)
-                    && int.TryParse(expectedArgumentIndexString, out var expectedArgumentIndex)
-                    && diagnostic.Properties.TryGetValue(ActualArgumentIndex, out var actualArgumentIndexString)
-                    && int.TryParse(actualArgumentIndexString, out var actualArgumentIndex)
+                if (diagnostic.TryGetIntProperty(ExpectedArgumentIndex, out var expectedArgumentIndex)
+                    && diagnostic.TryGetIntProperty(ActualArgumentIndex, out var actualArgumentIndex)
                     && root.FindNode(diagnostic.Location.SourceSpan).FirstAncestorOrSelf<InvocationExpressionSyntax>() is { } invocationSyntax
                     && invocationSyntax.ArgumentList.Arguments[expectedArgumentIndex] is var expectedArgumentSyntax
                     && invocationSyntax.ArgumentList.Arguments[actualArgumentIndex] is var actualArgumentSyntax

--- a/Funcky.Analyzers/Funcky.Analyzers.Test/FunctionalAssertAnalyzerTest.Setup.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers.Test/FunctionalAssertAnalyzerTest.Setup.cs
@@ -1,0 +1,43 @@
+namespace Funcky.Analyzers.Test;
+
+public sealed partial class FunctionalAssertAnalyzerTest
+{
+    // language=csharp
+    private const string AttributeSource =
+        """
+        namespace Funcky.CodeAnalysis
+        {
+            internal sealed class AssertMethodHasOverloadWithExpectedValueAttribute : System.Attribute { }
+        }
+        """;
+
+    // language=csharp
+    private const string Stubs =
+        """
+        namespace Xunit
+        {
+            public static class Assert
+            {
+                public static void Equal<T>(T expected, T actual) { }
+
+                public static void Equal<T>(T expected, T actual, System.Func<T, T, bool> compare) { }
+
+                public static void Equal(System.DateTime expected, System.DateTime actual) { }
+            }
+        }
+
+        namespace Funcky.Monads
+        {
+            public readonly struct Option<T> { }
+        }
+
+        namespace Funcky
+        {
+            public static class FunctionalAssert
+            {
+                [Funcky.CodeAnalysis.AssertMethodHasOverloadWithExpectedValueAttribute]
+                public static T Some<T>(Option<T> option) => throw null!;
+            }
+        }
+        """;
+}

--- a/Funcky.Analyzers/Funcky.Analyzers.Test/FunctionalAssertAnalyzerTest.Setup.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers.Test/FunctionalAssertAnalyzerTest.Setup.cs
@@ -37,6 +37,8 @@ public sealed partial class FunctionalAssertAnalyzerTest
             {
                 [Funcky.CodeAnalysis.AssertMethodHasOverloadWithExpectedValueAttribute]
                 public static T Some<T>(Option<T> option) => throw null!;
+
+                public static T Some<T>(T expected, Option<T> option) => throw null!;
             }
         }
         """;

--- a/Funcky.Analyzers/Funcky.Analyzers.Test/FunctionalAssertAnalyzerTest.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers.Test/FunctionalAssertAnalyzerTest.cs
@@ -1,0 +1,51 @@
+using Xunit;
+using VerifyCS = Funcky.Analyzers.Test.CSharpAnalyzerVerifier<Funcky.Analyzers.FunctionalAssert.FunctionalAssertAnalyzer>;
+
+namespace Funcky.Analyzers.Test;
+
+public sealed partial class FunctionalAssertAnalyzerTest
+{
+    [Fact]
+    public async Task WarnsWhenCombiningAssertEqualWithOurMethod()
+    {
+        // language=csharp
+        const string inputCode =
+            """
+            using Funcky;
+            using Funcky.Monads;
+            using Xunit;
+
+            class C
+            {
+                private void M()
+                {
+                    Assert.Equal(42, FunctionalAssert.Some(default(Option<int>)));
+                }
+            }
+            """;
+        await VerifyCS.VerifyAnalyzerAsync(inputCode + AttributeSource + Stubs);
+    }
+
+    [Fact]
+    public async Task DoesNotWarnForSpecializedOverloadsOfAssertEqual()
+    {
+        // language=csharp
+        const string inputCode =
+            """
+            using System;
+            using Funcky;
+            using Funcky.Monads;
+            using Xunit;
+
+            class C
+            {
+                private void M()
+                {
+                    Assert.Equal(DateTime.UnixEpoch, FunctionalAssert.Some(default(Option<DateTime>)));
+                    Assert.Equal(42, FunctionalAssert.Some(default(Option<int>)), (a, b) => throw null!);
+                }
+            }
+            """;
+        await VerifyCS.VerifyAnalyzerAsync(inputCode + AttributeSource + Stubs);
+    }
+}

--- a/Funcky.Analyzers/Funcky.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/Funcky.Analyzers/Funcky.Analyzers/AnalyzerReleases.Unshipped.md
@@ -4,3 +4,4 @@
 ### New Rules
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
+λ1101 | Funcky | Warning | FunctionalAssertAnalyzer

--- a/Funcky.Analyzers/Funcky.Analyzers/DiagnosticName.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers/DiagnosticName.cs
@@ -5,4 +5,6 @@ internal static class DiagnosticName
     public const string Prefix = "λ";
 
     public const string Usage = "10";
+
+    public const string FunctionalAssertUsage = "11";
 }

--- a/Funcky.Analyzers/Funcky.Analyzers/FunckyWellKnownMemberNames.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers/FunckyWellKnownMemberNames.cs
@@ -38,4 +38,9 @@ public static class FunckyWellKnownMemberNames
 
     /// <summary>The <c>ToNullable</c> method on alternative monad types.</summary>
     public const string ToNullableMethodName = "ToNullable";
+
+    public static class XunitAssert
+    {
+        public const string EqualMethodName = "Equal";
+    }
 }

--- a/Funcky.Analyzers/Funcky.Analyzers/FunckyWellKnownTypeNames.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers/FunckyWellKnownTypeNames.cs
@@ -27,4 +27,6 @@ public static class FunckyWellKnownTypeNames
     public static INamedTypeSymbol? GetFunctionalType(this Compilation compilation) => compilation.GetTypeByMetadataName("Funcky.Functional");
 
     public static INamedTypeSymbol? GetExpressionOfTType(this Compilation compilation) => compilation.GetTypeByMetadataName("System.Linq.Expressions.Expression`1");
+
+    public static INamedTypeSymbol? GetXunitAssertType(this Compilation compilation) => compilation.GetTypeByMetadataName("Xunit.Assert");
 }

--- a/Funcky.Analyzers/Funcky.Analyzers/FunctionalAssert/FunctionalAssertAnalyzer.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers/FunctionalAssert/FunctionalAssertAnalyzer.cs
@@ -1,0 +1,54 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using static Funcky.Analyzers.FunctionalAssert.FunctionalAssertMatching;
+using static Funcky.Analyzers.FunctionalAssert.XunitAssertMatching;
+
+namespace Funcky.Analyzers.FunctionalAssert;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class FunctionalAssertAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor PreferFunctionalAssert = new(
+        id: $"{DiagnosticName.Prefix}{DiagnosticName.FunctionalAssertUsage}01",
+        title: "Assert can be simplified",
+        messageFormat: "Assert can be simplified to a single call to {0}.{1}",
+        category: nameof(Funcky),
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    private const string AttributeFullName = "Funcky.CodeAnalysis.AssertMethodHasOverloadWithExpectedValueAttribute";
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(PreferFunctionalAssert);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(OnCompilationStart);
+    }
+
+    private static void OnCompilationStart(CompilationStartAnalysisContext context)
+    {
+        if (context.Compilation.GetTypeByMetadataName(AttributeFullName) is { } attributeType)
+        {
+            context.RegisterOperationAction(AnalyzeInvocation(new AssertMethodHasOverloadWithExpectedValueAttributeType(attributeType)), OperationKind.Invocation);
+        }
+    }
+
+    private static Action<OperationAnalysisContext> AnalyzeInvocation(AssertMethodHasOverloadWithExpectedValueAttributeType attributeType)
+        => context =>
+        {
+            var invocation = (IInvocationOperation)context.Operation;
+            if (MatchGenericAssertEqualInvocation(invocation, out var actualArgument)
+                && actualArgument.Value is IInvocationOperation innerInvocation
+                && IsAssertMethodWithAccompanyingEqualOverload(innerInvocation, attributeType))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    PreferFunctionalAssert,
+                    invocation.Syntax.GetLocation(),
+                    messageArgs: [innerInvocation.TargetMethod.ContainingType.Name, innerInvocation.TargetMethod.Name]));
+            }
+        };
+}

--- a/Funcky.Analyzers/Funcky.Analyzers/FunctionalAssert/FunctionalAssertAnalyzer.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers/FunctionalAssert/FunctionalAssertAnalyzer.cs
@@ -10,6 +10,9 @@ namespace Funcky.Analyzers.FunctionalAssert;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class FunctionalAssertAnalyzer : DiagnosticAnalyzer
 {
+    public const string ExpectedArgumentIndex = nameof(ExpectedArgumentIndex);
+    public const string ActualArgumentIndex = nameof(ActualArgumentIndex);
+
     public static readonly DiagnosticDescriptor PreferFunctionalAssert = new(
         id: $"{DiagnosticName.Prefix}{DiagnosticName.FunctionalAssertUsage}01",
         title: "Assert can be simplified",
@@ -41,13 +44,17 @@ public sealed class FunctionalAssertAnalyzer : DiagnosticAnalyzer
         => context =>
         {
             var invocation = (IInvocationOperation)context.Operation;
-            if (MatchGenericAssertEqualInvocation(invocation, out var actualArgument)
+            if (MatchGenericAssertEqualInvocation(invocation, out var expectedArgument, out var actualArgument)
                 && actualArgument.Value is IInvocationOperation innerInvocation
                 && IsAssertMethodWithAccompanyingEqualOverload(innerInvocation, attributeType))
             {
+                var properties = ImmutableDictionary<string, string?>.Empty
+                    .Add(ActualArgumentIndex, invocation.Arguments.IndexOf(actualArgument).ToString())
+                    .Add(ExpectedArgumentIndex, invocation.Arguments.IndexOf(expectedArgument).ToString());
                 context.ReportDiagnostic(Diagnostic.Create(
                     PreferFunctionalAssert,
                     invocation.Syntax.GetLocation(),
+                    properties,
                     messageArgs: [innerInvocation.TargetMethod.ContainingType.Name, innerInvocation.TargetMethod.Name]));
             }
         };

--- a/Funcky.Analyzers/Funcky.Analyzers/FunctionalAssert/FunctionalAssertMatching.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers/FunctionalAssert/FunctionalAssertMatching.cs
@@ -1,0 +1,18 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Funcky.Analyzers.FunctionalAssert;
+
+public sealed class FunctionalAssertMatching
+{
+    public static bool IsAssertMethodWithAccompanyingEqualOverload(
+        IInvocationOperation invocation,
+        AssertMethodHasOverloadWithExpectedValueAttributeType attributeType)
+        => invocation.TargetMethod.GetAttributes().Any(IsAttribute(attributeType.Value))
+            && invocation.Arguments.Length == 1;
+
+    private static Func<AttributeData, bool> IsAttribute(INamedTypeSymbol attributeType)
+        => data => SymbolEqualityComparer.Default.Equals(data.AttributeClass, attributeType);
+}
+
+public sealed record AssertMethodHasOverloadWithExpectedValueAttributeType(INamedTypeSymbol Value);

--- a/Funcky.Analyzers/Funcky.Analyzers/FunctionalAssert/XunitAssertMatching.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers/FunctionalAssert/XunitAssertMatching.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+using static Funcky.Analyzers.FunckyWellKnownMemberNames;
+
+namespace Funcky.Analyzers.FunctionalAssert;
+
+internal sealed class XunitAssertMatching
+{
+    public static bool MatchGenericAssertEqualInvocation(IInvocationOperation invocation, [NotNullWhen(true)] out IArgumentOperation? actualArgument)
+    {
+        const int actualArgumentIndex = 1;
+        actualArgument = null;
+        return invocation.TargetMethod.Name == XunitAssert.EqualMethodName
+           && invocation.SemanticModel?.Compilation.GetXunitAssertType() is { } assertType
+           && SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.ContainingType, assertType)
+           && invocation.TargetMethod.TypeParameters is [var typeParameter]
+           && invocation.TargetMethod.OriginalDefinition.Parameters is [var firstParameter, var secondParameter]
+           && SymbolEqualityComparer.Default.Equals(firstParameter.Type, typeParameter)
+           && SymbolEqualityComparer.Default.Equals(secondParameter.Type, typeParameter)
+           && (actualArgument = invocation.GetArgumentForParameterAtIndex(actualArgumentIndex)) is var _;
+    }
+}

--- a/Funcky.Analyzers/Funcky.Analyzers/FunctionalAssert/XunitAssertMatching.cs
+++ b/Funcky.Analyzers/Funcky.Analyzers/FunctionalAssert/XunitAssertMatching.cs
@@ -7,9 +7,14 @@ namespace Funcky.Analyzers.FunctionalAssert;
 
 internal sealed class XunitAssertMatching
 {
-    public static bool MatchGenericAssertEqualInvocation(IInvocationOperation invocation, [NotNullWhen(true)] out IArgumentOperation? actualArgument)
+    public static bool MatchGenericAssertEqualInvocation(
+        IInvocationOperation invocation,
+        [NotNullWhen(true)] out IArgumentOperation? expectedArgument,
+        [NotNullWhen(true)] out IArgumentOperation? actualArgument)
     {
-        const int actualArgumentIndex = 1;
+        const int expectedParameterIndex = 0;
+        const int actualParameterIndex = 1;
+        expectedArgument = null;
         actualArgument = null;
         return invocation.TargetMethod.Name == XunitAssert.EqualMethodName
            && invocation.SemanticModel?.Compilation.GetXunitAssertType() is { } assertType
@@ -18,6 +23,7 @@ internal sealed class XunitAssertMatching
            && invocation.TargetMethod.OriginalDefinition.Parameters is [var firstParameter, var secondParameter]
            && SymbolEqualityComparer.Default.Equals(firstParameter.Type, typeParameter)
            && SymbolEqualityComparer.Default.Equals(secondParameter.Type, typeParameter)
-           && (actualArgument = invocation.GetArgumentForParameterAtIndex(actualArgumentIndex)) is var _;
+           && (expectedArgument = invocation.GetArgumentForParameterAtIndex(expectedParameterIndex)) is var _
+           && (actualArgument = invocation.GetArgumentForParameterAtIndex(actualParameterIndex)) is var _;
     }
 }

--- a/Funcky.Test/Extensions/EnumerableExtensions/ElementAtOrNoneTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/ElementAtOrNoneTest.cs
@@ -20,11 +20,11 @@ public sealed class ElementAtOrNoneTest
 
         FunctionalAssert.None(range.ElementAtOrNone(-42));
         FunctionalAssert.None(range.ElementAtOrNone(-1));
-        Assert.Equal(1, FunctionalAssert.Some(range.ElementAtOrNone(0)));
-        Assert.Equal(2, FunctionalAssert.Some(range.ElementAtOrNone(1)));
-        Assert.Equal(3, FunctionalAssert.Some(range.ElementAtOrNone(2)));
-        Assert.Equal(4, FunctionalAssert.Some(range.ElementAtOrNone(3)));
-        Assert.Equal(5, FunctionalAssert.Some(range.ElementAtOrNone(4)));
+        FunctionalAssert.Some(1, range.ElementAtOrNone(0));
+        FunctionalAssert.Some(2, range.ElementAtOrNone(1));
+        FunctionalAssert.Some(3, range.ElementAtOrNone(2));
+        FunctionalAssert.Some(4, range.ElementAtOrNone(3));
+        FunctionalAssert.Some(5, range.ElementAtOrNone(4));
         FunctionalAssert.None(range.ElementAtOrNone(5));
         FunctionalAssert.None(range.ElementAtOrNone(42));
         FunctionalAssert.None(range.ElementAtOrNone(1337));

--- a/Funcky.Test/Extensions/EnumerableExtensions/GetNonEnumeratedCountOrNoneTest.cs
+++ b/Funcky.Test/Extensions/EnumerableExtensions/GetNonEnumeratedCountOrNoneTest.cs
@@ -23,7 +23,7 @@ public class GetNonEnumeratedCountOrNoneTest
 
         var range = Enumerable.Range(1, count);
 
-        Assert.Equal(count, FunctionalAssert.Some(range.GetNonEnumeratedCountOrNone()));
+        FunctionalAssert.Some(count, range.GetNonEnumeratedCountOrNone());
     }
 
     [Property]

--- a/Funcky.Test/Monads/OptionTest.cs
+++ b/Funcky.Test/Monads/OptionTest.cs
@@ -226,10 +226,10 @@ public sealed partial class OptionTest
         var some = Option.Some(42);
 
         FunctionalAssert.None(none.AndThen(_ => 1337));
-        Assert.Equal(1337, FunctionalAssert.Some(some.AndThen(_ => 1337)));
+        FunctionalAssert.Some(1337, some.AndThen(_ => 1337));
 
         FunctionalAssert.None(none.AndThen(_ => Option.Some(1337)));
-        Assert.Equal(1337, FunctionalAssert.Some(some.AndThen(_ => Option.Some(1337))));
+        FunctionalAssert.Some(1337, some.AndThen(_ => Option.Some(1337)));
     }
 
     [Fact]

--- a/Funcky.Xunit/CodeAnalysis/AssertMethodHasOverloadWithExpectedValueAttribute.cs
+++ b/Funcky.Xunit/CodeAnalysis/AssertMethodHasOverloadWithExpectedValueAttribute.cs
@@ -1,0 +1,6 @@
+namespace Funcky.CodeAnalysis;
+
+/// <summary>Marks <c>FunctionalAssert</c> methods that have an accompanying overload that
+/// takes the expected value.</summary>
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class AssertMethodHasOverloadWithExpectedValueAttribute : Attribute;

--- a/Funcky.Xunit/FunctionalAssert/Left.cs
+++ b/Funcky.Xunit/FunctionalAssert/Left.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Funcky.CodeAnalysis;
 using Xunit.Sdk;
 using static Xunit.Sdk.ArgumentFormatter;
 
@@ -41,6 +42,7 @@ public static partial class FunctionalAssert
     /// <summary>Asserts that the given <paramref name="either"/> is <c>Left</c>.</summary>
     /// <exception cref="XunitException">Thrown when <paramref name="either"/> is <c>Right</c>.</exception>
     /// <returns>Returns the value in <paramref name="either"/> if it was <c>Left</c>.</returns>
+    [AssertMethodHasOverloadWithExpectedValue]
     #if STACK_TRACE_HIDDEN_SUPPORTED
     [System.Diagnostics.StackTraceHidden]
     #else

--- a/Funcky.Xunit/FunctionalAssert/Ok.cs
+++ b/Funcky.Xunit/FunctionalAssert/Ok.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Funcky.CodeAnalysis;
 using Xunit.Sdk;
 using static Xunit.Sdk.ArgumentFormatter;
 
@@ -40,6 +41,7 @@ public static partial class FunctionalAssert
     /// <summary>Asserts that the given <paramref name="result"/> is <c>Ok</c>.</summary>
     /// <exception cref="XunitException">Thrown when <paramref name="result"/> is <c>Error</c>.</exception>
     /// <returns>Returns the value in <paramref name="result"/> if it was <c>Ok</c>.</returns>
+    [AssertMethodHasOverloadWithExpectedValue]
     #if STACK_TRACE_HIDDEN_SUPPORTED
     [System.Diagnostics.StackTraceHidden]
     #else

--- a/Funcky.Xunit/FunctionalAssert/Right.cs
+++ b/Funcky.Xunit/FunctionalAssert/Right.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Funcky.CodeAnalysis;
 using Xunit.Sdk;
 using static Xunit.Sdk.ArgumentFormatter;
 
@@ -41,6 +42,7 @@ public static partial class FunctionalAssert
     /// <summary>Asserts that the given <paramref name="either"/> is <c>Right</c>.</summary>
     /// <exception cref="XunitException">Thrown when <paramref name="either"/> is <c>Left</c>.</exception>
     /// <returns>Returns the value in <paramref name="either"/> if it was <c>Right</c>.</returns>
+    [AssertMethodHasOverloadWithExpectedValue]
     #if STACK_TRACE_HIDDEN_SUPPORTED
     [System.Diagnostics.StackTraceHidden]
     #else

--- a/Funcky.Xunit/FunctionalAssert/Some.cs
+++ b/Funcky.Xunit/FunctionalAssert/Some.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Funcky.CodeAnalysis;
 using Xunit.Sdk;
 using static Xunit.Sdk.ArgumentFormatter;
 
@@ -40,6 +41,7 @@ public static partial class FunctionalAssert
     /// <summary>Asserts that the given <paramref name="option"/> is <c>Some</c>.</summary>
     /// <exception cref="XunitException">Thrown when <paramref name="option"/> is <c>None</c>.</exception>
     /// <returns>Returns the value in <paramref name="option"/> if it was <c>Some</c>.</returns>
+    [AssertMethodHasOverloadWithExpectedValue]
     [Pure]
     #if STACK_TRACE_HIDDEN_SUPPORTED
     [System.Diagnostics.StackTraceHidden]


### PR DESCRIPTION
Resolves #749

The analyzer recommends `FunctionalAssert.Foo(expected, actual)` over `Assert.Equal(expected, FunctionalAssert.Foo(actual))`