### PR TITLE
Update Copyright in License Files

### DIFF
--- a/LICENSE-Apache
+++ b/LICENSE-Apache
@@ -1,4 +1,4 @@
-Copyright (c) 2019, Messerli Informatik AG - This library is dual licensed
+Copyright (c) 2019, Polyadic - This library is dual licensed
 
                                  Apache License
                            Version 2.0, January 2004

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2019, Messerli Informatik AG - This library is dual licensed
+Copyright (c) 2019, Polyadic - This library is dual licensed
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
The license files currently claim that the copyright is with Messerli,
but all our other sources (NuGet metadata) says Polyadic. I assume that the license files were copied from other projects and never updated.