### PR TITLE
Always run public API analyzers on newest target framework

### DIFF
--- a/Funcky.Async/Funcky.Async.csproj
+++ b/Funcky.Async/Funcky.Async.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net9.0;net8.0;net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+        <FunckyNewestTargetFramework>net9.0</FunckyNewestTargetFramework>
+        <TargetFrameworks>$(FunckyNewestTargetFramework);net8.0;net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
         <LangVersion>preview</LangVersion>
         <Nullable>enable</Nullable>
         <Description>Extends Funcky with support for IAsyncEnumerable and Tasks.</Description>
@@ -29,6 +30,11 @@
     <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">
         <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
+    <!-- These files are included by Microsoft.CodeAnalysis.PublicApiAnalyzers is included. -->
+    <ItemGroup Condition="'$(TargetFramework)' != '$(FunckyNewestTargetFramework)'">
+        <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+        <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+    </ItemGroup>
     <ItemGroup>
         <Compile Include="..\Funcky\Internal\Aggregators\DecimalAverageAggregator.cs" Link="Internal\Aggregators\DecimalAverageAggregator.cs" />
         <Compile Include="..\Funcky\Internal\Aggregators\DoubleAverageAggregator.cs" Link="Internal\Aggregators\DoubleAverageAggregator.cs" />
@@ -43,7 +49,7 @@
         <Compile Include="..\Funcky\Internal\PartitionBuilder.cs" Link="Internal\PartitionBuilder.cs" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net5.0'" />
+        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" Condition="'$(TargetFramework)' == '$(FunckyNewestTargetFramework)'" />
         <PackageReference Include="PolySharp" PrivateAssets="all" />
         <PackageReference Include="Polyadic.Build.SemanticVersioning" PrivateAssets="all" />
         <PackageReference Include="System.Linq.Async" />

--- a/Funcky.Async/Funcky.Async.csproj
+++ b/Funcky.Async/Funcky.Async.csproj
@@ -30,11 +30,6 @@
     <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">
         <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
-    <!-- These files are included by Microsoft.CodeAnalysis.PublicApiAnalyzers is included. -->
-    <ItemGroup Condition="'$(TargetFramework)' != '$(FunckyNewestTargetFramework)'">
-        <AdditionalFiles Include="PublicAPI.Shipped.txt" />
-        <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
-    </ItemGroup>
     <ItemGroup>
         <Compile Include="..\Funcky\Internal\Aggregators\DecimalAverageAggregator.cs" Link="Internal\Aggregators\DecimalAverageAggregator.cs" />
         <Compile Include="..\Funcky\Internal\Aggregators\DoubleAverageAggregator.cs" Link="Internal\Aggregators\DoubleAverageAggregator.cs" />
@@ -49,7 +44,6 @@
         <Compile Include="..\Funcky\Internal\PartitionBuilder.cs" Link="Internal\PartitionBuilder.cs" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" Condition="'$(TargetFramework)' == '$(FunckyNewestTargetFramework)'" />
         <PackageReference Include="PolySharp" PrivateAssets="all" />
         <PackageReference Include="Polyadic.Build.SemanticVersioning" PrivateAssets="all" />
         <PackageReference Include="System.Linq.Async" />
@@ -64,4 +58,5 @@
     <Import Project="..\Analyzers.props" />
     <Import Project="..\GlobalUsings.props" />
     <Import Project="..\FrameworkFeatureConstants.props" />
+    <Import Project="..\PublicApiAnalyzers.targets" />
 </Project>

--- a/Funcky.Xunit.v3/Funcky.Xunit.v3.csproj
+++ b/Funcky.Xunit.v3/Funcky.Xunit.v3.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+        <FunckyNewestTargetFramework>net6.0</FunckyNewestTargetFramework>
+        <TargetFrameworks>$(FunckyNewestTargetFramework);netstandard2.0</TargetFrameworks>
         <LangVersion>preview</LangVersion>
         <Nullable>enable</Nullable>
         <Description>Package to use Funcky with xUnit v3</Description>
@@ -36,7 +37,6 @@
         <PackageReference Include="Polyadic.Build.SemanticVersioning" PrivateAssets="all" />
         <PackageReference Include="xunit.v3.assert" />
         <PackageReference Include="xunit.v3.extensibility.core" />
-        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net6.0'" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../Funcky/Funcky.csproj" />
@@ -46,4 +46,5 @@
     </ItemGroup>
     <Import Project="..\Analyzers.props" />
     <Import Project="..\GlobalUsings.props" />
+    <Import Project="..\PublicApiAnalyzers.targets" />
 </Project>

--- a/Funcky.Xunit/Funcky.Xunit.csproj
+++ b/Funcky.Xunit/Funcky.Xunit.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+        <FunckyNewestTargetFramework>net6.0</FunckyNewestTargetFramework>
+        <TargetFrameworks>$(FunckyNewestTargetFramework);netstandard2.0</TargetFrameworks>
         <LangVersion>preview</LangVersion>
         <Nullable>enable</Nullable>
         <Description>Package to use Funcky with xUnit</Description>
@@ -24,7 +25,6 @@
         <PackageReference Include="Polyadic.Build.SemanticVersioning" PrivateAssets="all" />
         <PackageReference Include="xunit.assert" />
         <PackageReference Include="xunit.extensibility.core" />
-        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net6.0'" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../Funcky/Funcky.csproj" />
@@ -35,4 +35,5 @@
     </ItemGroup>
     <Import Project="..\Analyzers.props" />
     <Import Project="..\GlobalUsings.props" />
+    <Import Project="..\PublicApiAnalyzers.targets" />
 </Project>

--- a/Funcky.sln
+++ b/Funcky.sln
@@ -27,6 +27,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build Config", "Build Confi
 		GlobalUsings.Test.props = GlobalUsings.Test.props
 		NuGet.config = NuGet.config
 		typos.toml = typos.toml
+		PublicApiAnalyzers.targets = PublicApiAnalyzers.targets
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Funcky.Xunit", "Funcky.Xunit\Funcky.Xunit.csproj", "{F2E98B0D-CC17-4576-89DE-065FF475BE6E}"

--- a/Funcky/Funcky.csproj
+++ b/Funcky/Funcky.csproj
@@ -23,7 +23,6 @@
         <DefineConstants>$(DefineConstants);CONTRACTS_FULL</DefineConstants>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" Condition="'$(TargetFramework)' == '$(FunckyNewestTargetFramework)'" />
         <PackageReference Include="Microsoft.Bcl.HashCode" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
         <PackageReference Include="PolySharp" PrivateAssets="all" />
         <PackageReference Include="System.Collections.Immutable" Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1'" />
@@ -33,11 +32,6 @@
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Funcky.SourceGenerator\Funcky.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
-    </ItemGroup>
-    <!-- These files are included by Microsoft.CodeAnalysis.PublicApiAnalyzers is included. -->
-    <ItemGroup Condition="'$(TargetFramework)' != '$(FunckyNewestTargetFramework)'">
-        <AdditionalFiles Include="PublicAPI.Shipped.txt" />
-        <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
     </ItemGroup>
     <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
         <IsTrimmable>true</IsTrimmable>
@@ -63,4 +57,5 @@
     <Import Project="..\Analyzers.props" />
     <Import Project="..\GlobalUsings.props" />
     <Import Project="..\FrameworkFeatureConstants.props" />
+    <Import Project="..\PublicApiAnalyzers.targets" />
 </Project>

--- a/Funcky/Funcky.csproj
+++ b/Funcky/Funcky.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net9.0;net8.0;net7.0;net6.0;net5.0;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <FunckyNewestTargetFramework>net9.0</FunckyNewestTargetFramework>
+        <TargetFrameworks>$(FunckyNewestTargetFramework);net8.0;net7.0;net6.0;net5.0;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>preview</LangVersion>
         <Nullable>enable</Nullable>
         <Product>Funcky</Product>
@@ -20,10 +21,9 @@
     </PropertyGroup>
     <PropertyGroup>
         <DefineConstants>$(DefineConstants);CONTRACTS_FULL</DefineConstants>
-        <TargetFrameworkForPublicApiAnalyzers>net9.0</TargetFrameworkForPublicApiAnalyzers>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" Condition="'$(TargetFramework)' == '$(TargetFrameworkForPublicApiAnalyzers)'" />
+        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" Condition="'$(TargetFramework)' == '$(FunckyNewestTargetFramework)'" />
         <PackageReference Include="Microsoft.Bcl.HashCode" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
         <PackageReference Include="PolySharp" PrivateAssets="all" />
         <PackageReference Include="System.Collections.Immutable" Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1'" />
@@ -35,7 +35,7 @@
         <ProjectReference Include="..\Funcky.SourceGenerator\Funcky.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
     </ItemGroup>
     <!-- These files are included by Microsoft.CodeAnalysis.PublicApiAnalyzers is included. -->
-    <ItemGroup Condition="'$(TargetFramework)' != '$(TargetFrameworkForPublicApiAnalyzers)'">
+    <ItemGroup Condition="'$(TargetFramework)' != '$(FunckyNewestTargetFramework)'">
         <AdditionalFiles Include="PublicAPI.Shipped.txt" />
         <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
     </ItemGroup>

--- a/PublicApiAnalyzers.targets
+++ b/PublicApiAnalyzers.targets
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<!-- We intentionally only include the public API analyzers for the newest target
+	     framework because we often add APIs in newer target frameworks
+	     that we don't add for older target frameworks. -->
 	<ItemGroup Condition="'$(TargetFramework)' == '$(FunckyNewestTargetFramework)'">
 		<PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
 	</ItemGroup>

--- a/PublicApiAnalyzers.targets
+++ b/PublicApiAnalyzers.targets
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<ItemGroup Condition="'$(TargetFramework)' == '$(FunckyNewestTargetFramework)'">
+		<PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
+	</ItemGroup>
+	<!-- These files are included by Microsoft.CodeAnalysis.PublicApiAnalyzers if it is enabled. -->
+	<ItemGroup Condition="'$(TargetFramework)' != '$(FunckyNewestTargetFramework)'">
+		<AdditionalFiles Include="PublicAPI.Shipped.txt" />
+		<AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+	</ItemGroup>
+	<PropertyGroup>
+		<CoreCompileDependsOn>$(CoreCompileDependsOn);_ValidateFunckyNewestTargetFrameworkIsSet</CoreCompileDependsOn>
+	</PropertyGroup>
+	<Target	Name="_ValidateFunckyNewestTargetFrameworkIsSet" Condition="'$(FunckyNewestTargetFramework)' == ''">
+		<PropertyGroup>
+			<_Text>The 'FunckyNewestTargetFramework' property is not set; public API analyzers will not run</_Text>
+		</PropertyGroup>
+		<Warning Text="$(_Text)" File="$(MSBuildProjectFullPath)" Condition="'$(TreatWarningsAsErrors)' != 'true'" />
+		<Error Text="$(_Text)" File="$(MSBuildProjectFullPath)" Condition="'$(TreatWarningsAsErrors)' == 'true'" />
+	</Target>
+</Project>


### PR DESCRIPTION
We intentionally run the public API analyzers only on the newest target framework because we usually add APIs in newer target frameworks that are missing in older ones.

I have sometimes forgotten to update the target framework condition (for instance in Funcky.Async). To prevent this I introduced a property `FunckyNewestTargetFramework` that sits right next to the other target frameworks so that they (hopefully) get bumped together.

We also get a warning now if we don't set the property altogether.